### PR TITLE
Add ws to client

### DIFF
--- a/pyth-common-js/.eslintrc.js
+++ b/pyth-common-js/.eslintrc.js
@@ -5,5 +5,7 @@ module.exports = {
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   rules: {
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-empty-function": "off",
   },
 };

--- a/pyth-common-js/package-lock.json
+++ b/pyth-common-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-common-js",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-common-js",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/pyth-sdk-js": "^0.1.0",

--- a/pyth-common-js/package-lock.json
+++ b/pyth-common-js/package-lock.json
@@ -10,8 +10,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/pyth-sdk-js": "^0.1.0",
+        "@types/ws": "^8.5.3",
         "axios": "^0.26.1",
-        "axios-retry": "^3.2.4"
+        "axios-retry": "^3.2.4",
+        "isomorphic-ws": "^4.0.1",
+        "ts-log": "^2.2.4",
+        "ws": "^8.6.0"
       },
       "devDependencies": {
         "@types/jest": "^27.4.1",
@@ -1131,8 +1135,7 @@
     "node_modules/@types/node": {
       "version": "17.0.26",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.26.tgz",
-      "integrity": "sha512-z/FG/6DUO7pnze3AE3TBGIjGGKkvCcGcWINe1C7cADY8hKLJPDYpzsNE37uExQ4md5RFtTCvg+M8Mu1Enyeg2A==",
-      "dev": true
+      "integrity": "sha512-z/FG/6DUO7pnze3AE3TBGIjGGKkvCcGcWINe1C7cADY8hKLJPDYpzsNE37uExQ4md5RFtTCvg+M8Mu1Enyeg2A=="
     },
     "node_modules/@types/prettier": {
       "version": "2.6.0",
@@ -1145,6 +1148,14 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.10",
@@ -3030,6 +3041,14 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -3803,6 +3822,27 @@
       },
       "peerDependenciesMeta": {
         "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }
@@ -4875,6 +4915,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/ts-log": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.4.tgz",
+      "integrity": "sha512-DEQrfv6l7IvN2jlzc/VTdZJYsWUnQNCsueYjMkC/iXoEoi5fNan6MjeDqkvhfzbmHgdz9UxDUluX3V5HdjTydQ=="
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -5126,12 +5171,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true,
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
+      "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -6091,8 +6135,7 @@
     "@types/node": {
       "version": "17.0.26",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.26.tgz",
-      "integrity": "sha512-z/FG/6DUO7pnze3AE3TBGIjGGKkvCcGcWINe1C7cADY8hKLJPDYpzsNE37uExQ4md5RFtTCvg+M8Mu1Enyeg2A==",
-      "dev": true
+      "integrity": "sha512-z/FG/6DUO7pnze3AE3TBGIjGGKkvCcGcWINe1C7cADY8hKLJPDYpzsNE37uExQ4md5RFtTCvg+M8Mu1Enyeg2A=="
     },
     "@types/prettier": {
       "version": "2.6.0",
@@ -6105,6 +6148,14 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/ws": {
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "17.0.10",
@@ -7474,6 +7525,12 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "requires": {}
+    },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -8081,6 +8138,15 @@
         "whatwg-url": "^8.5.0",
         "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.5.7",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+          "dev": true,
+          "requires": {}
+        }
       }
     },
     "jsesc": {
@@ -8847,6 +8913,11 @@
         }
       }
     },
+    "ts-log": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.4.tgz",
+      "integrity": "sha512-DEQrfv6l7IvN2jlzc/VTdZJYsWUnQNCsueYjMkC/iXoEoi5fNan6MjeDqkvhfzbmHgdz9UxDUluX3V5HdjTydQ=="
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -9042,10 +9113,9 @@
       }
     },
     "ws": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true,
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
+      "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
       "requires": {}
     },
     "xml-name-validator": {

--- a/pyth-common-js/package.json
+++ b/pyth-common-js/package.json
@@ -43,7 +43,11 @@
   },
   "dependencies": {
     "@pythnetwork/pyth-sdk-js": "^0.1.0",
+    "@types/ws": "^8.5.3",
     "axios": "^0.26.1",
-    "axios-retry": "^3.2.4"
+    "axios-retry": "^3.2.4",
+    "isomorphic-ws": "^4.0.1",
+    "ts-log": "^2.2.4",
+    "ws": "^8.6.0"
   }
 }

--- a/pyth-common-js/package.json
+++ b/pyth-common-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-common-js",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Pyth Network Common Utils in JS",
   "author": {
     "name": "Pyth Data Association"

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -73,8 +73,8 @@ export class PriceServiceConnection {
     this.wsIsAlive = false;
     this.logger = config.logger;
     this.wsFailedAttempts = 0;
-    this.onWsError = (err: Error) => {
-      throw err;
+    this.onWsError = (error: Error) => {
+      this.logger?.error(error);
     };
     this.wsClosed = true;
   }

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -199,7 +199,7 @@ export class PriceServiceConnection {
 
     this.wsClient = new ResilientWebSocket(this.wsEndpoint, this.logger);
 
-    this.wsClient.onWsError = this.onWsError;
+    this.wsClient.onError = this.onWsError;
 
     this.wsClient.onReconnect = () => {
       if (this.priceFeedCallbacks.size > 0) {

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -213,7 +213,7 @@ export class PriceServiceConnection {
       }
     };
 
-    this.wsClient.onMessage = (data: WebSocket.RawData) => {
+    this.wsClient.onMessage = (data: WebSocket.Data) => {
       this.logger?.info(`Received message ${data.toString()}`);
 
       let message: ServerMessage;

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -133,9 +133,9 @@ export class PriceServiceConnection {
       throw new Error("WS is not started.");
     }
 
-    let newPriceIds: HexString[] = [];
+    const newPriceIds: HexString[] = [];
 
-    for (let id of priceIds) {
+    for (const id of priceIds) {
       if (!this.priceFeedCallbacks.has(id)) {
         this.priceFeedCallbacks.set(id, new Set());
         newPriceIds.push(id);
@@ -160,9 +160,9 @@ export class PriceServiceConnection {
       throw new Error("WS is not started.");
     }
 
-    let removedPriceIds: HexString[] = [];
+    const removedPriceIds: HexString[] = [];
 
-    for (let id of priceIds) {
+    for (const id of priceIds) {
       if (this.priceFeedCallbacks.has(id)) {
         let idRemoved = false;
 
@@ -250,7 +250,7 @@ export class PriceServiceConnection {
             `No callback for price id ${priceFeed.id}. It should only happen in a race condition`
           );
         } else {
-          for (let cb of this.priceFeedCallbacks.get(priceFeed.id)!) {
+          for (const cb of this.priceFeedCallbacks.get(priceFeed.id)!) {
             cb(priceFeed);
           }
         }

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -9,7 +9,7 @@ import { makeWebsocketUrl } from "./utils";
 export type DurationInMs = number;
 
 export type PriceServiceConnectionConfig = {
-  /* Optional WebSocket Endpoint of the price service if it has host/port than the endpoint. */
+  /* Optional websocket endpoint of the price service if it has host/port other than the endpoint. */
   wsEndpoint?: string;
   /* Timeout of each request (for all of retries). Default: 5000ms */
   timeout?: DurationInMs;
@@ -266,7 +266,7 @@ export class PriceServiceConnection {
       if (message.type === "response") {
         if (message.status === "error") {
           this.logger?.error(
-            `Error Response from the websocket server ${message.error}.`
+            `Error response from the websocket server ${message.error}.`
           );
           this.onWsError(new Error(message.error));
         }

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -1,35 +1,82 @@
 import { HexString, PriceFeed } from "@pythnetwork/pyth-sdk-js";
 import axios, { AxiosInstance } from "axios";
 import axiosRetry from "axios-retry";
+import * as WebSocket from "isomorphic-ws";
+import { Logger } from "ts-log";
 
 export type DurationInMs = number;
 
 export type PriceServiceConnectionConfig = {
   /* HTTP Endpoint of the price service. Example: https://website/example */
   httpEndpoint: string;
+  /* WebSocket Endpoint of the price service. Example: wss://website/example */
+  wsEndpoint?: string;
   /* Timeout of each request (for all of retries). Default: 5000ms */
   timeout?: DurationInMs;
   /**
-   * Number of times a request will be retried before the API returns a failure. Default: 3.
+   * Number of times a HTTP request will be retried before the API returns a failure. Default: 3.
    *
    * The connection uses exponential back-off for the delay between retries. However,
    * it will timeout regardless of the retries at the configured `timeout` time.
    */
-  retries?: number;
+  httpRetries?: number;
+  logger?: Logger;
 };
 
+type ClientMessage = {
+  type: "subscribe" | "unsubscribe";
+  ids: HexString[];
+};
+
+type ServerResponse = {
+  type: "response";
+  status: "success" | "error";
+  error?: string;
+};
+
+type ServerPriceUpdate = {
+  type: "price_update";
+  price_feed: any;
+};
+
+type ServerMessage = ServerResponse | ServerPriceUpdate;
+
+export type PriceFeedUpdateCallback = (priceFeed: PriceFeed) => any;
+
 export class PriceServiceConnection {
-  private client: AxiosInstance;
+  private httpClient: AxiosInstance;
+
+  private wsEndpoint: undefined | string;
+  private wsClient: undefined | WebSocket;
+  private wsClosed: boolean;
+  private priceFeedCallbacks: Map<HexString, Set<PriceFeedUpdateCallback>>;
+  private wsIsAlive: boolean;
+  private wsFailedAttempts: number;
+
+  // FIXME: document
+  onWsError: (error: Error) => any;
+
+  private logger: undefined | Logger;
 
   constructor(config: PriceServiceConnectionConfig) {
-    this.client = axios.create({
+    this.httpClient = axios.create({
       baseURL: config.httpEndpoint,
       timeout: config.timeout || 5000,
     });
-    axiosRetry(this.client, {
-      retries: config.retries || 3,
+    axiosRetry(this.httpClient, {
+      retries: config.httpRetries || 3,
       retryDelay: axiosRetry.exponentialDelay,
     });
+
+    this.wsEndpoint = config.wsEndpoint;
+    this.priceFeedCallbacks = new Map();
+    this.wsIsAlive = false;
+    this.logger = config.logger;
+    this.wsFailedAttempts = 0;
+    this.onWsError = (err: Error) => {
+      throw err;
+    };
+    this.wsClosed = true;
   }
 
   /**
@@ -46,7 +93,7 @@ export class PriceServiceConnection {
       return [];
     }
 
-    const response = await this.client.get("/latest_price_feeds", {
+    const response = await this.httpClient.get("/latest_price_feeds", {
       params: {
         ids: priceIds,
       },
@@ -69,11 +116,246 @@ export class PriceServiceConnection {
    * @returns Array of base64 encoded VAAs.
    */
   protected async getLatestVaas(priceIds: HexString[]): Promise<string[]> {
-    const response = await this.client.get("/latest_vaas", {
+    const response = await this.httpClient.get("/latest_vaas", {
       params: {
         ids: priceIds,
       },
     });
     return response.data;
   }
+
+  private async createWebSocket() {
+    if (this.wsEndpoint === undefined) {
+      throw new Error("undefined wsEndpoint.");
+    }
+
+    if (this.wsClient !== undefined) {
+      return;
+    }
+
+    this.logger?.info(`Creating Web Socket client`);
+
+    this.wsClient = new WebSocket(this.wsEndpoint!);
+    this.wsIsAlive = true;
+    this.wsClosed = false;
+
+    this.wsClient.on("open", () => {
+      this.wsFailedAttempts = 0;
+    });
+
+    this.wsClient.on("error", this.onWsError);
+
+    this.wsClient.on("message", (data: WebSocket.RawData) => {
+      this.logger?.info(`Received message ${data.toString()}`);
+
+      let message: ServerMessage;
+
+      try {
+        message = JSON.parse(data.toString()) as ServerMessage;
+      } catch (e: any) {
+        this.logger?.error(`Error parsing message ${data.toString()} as JSON.`);
+        this.logger?.error(e);
+        this.onWsError(e);
+        return;
+      }
+
+      if (message.type === "response" && message.status === "error") {
+        this.logger?.error(`Error Response from WS server`);
+      } else if (message.type === "price_update") {
+        let priceFeed;
+        try {
+          priceFeed = PriceFeed.fromJson(message.price_feed);
+        } catch (e: any) {
+          this.logger?.error(
+            `Error parsing Price Feeds from message ${data.toString()}`
+          );
+          this.logger?.error(e);
+          this.onWsError(e);
+          return;
+        }
+
+        if (!this.priceFeedCallbacks.has(priceFeed.id)) {
+          this.logger?.info(
+            `No callback for price id ${priceFeed.id}. It should only happen in a race condition`
+          );
+        } else {
+          for (let cb of this.priceFeedCallbacks.get(priceFeed.id)!) {
+            cb(priceFeed);
+          }
+        }
+      } else {
+        this.logger?.warn(
+          `Received unsupported message ${data.toString()}. Ignoring it`
+        );
+      }
+    });
+
+    this.wsClient.on("pong", (_data) => {
+      this.logger?.info("Websocket Pong");
+      this.wsIsAlive = true;
+    });
+
+    const pingInterval = setInterval(() => {
+      if (this.wsIsAlive === false) {
+        this.logger?.warn(`Websocket timed out. Restarting websocket.`);
+
+        this.wsClient?.close();
+        return;
+      }
+
+      this.logger?.info("Websocket Ping");
+
+      this.wsIsAlive = false;
+      this.wsClient?.ping();
+    }, 30000);
+
+    this.wsClient.on("close", async () => {
+      clearInterval(pingInterval);
+      if (this.wsClosed === false) {
+        this.logger?.error(
+          `Connection closed unexpected or because of timeout. Reconnecting.`
+        );
+        this.wsFailedAttempts += 1;
+        this.wsClient = undefined;
+        await waitExpoBackoff(this.wsFailedAttempts);
+        this.restartClosedWebsocket();
+      } else {
+        this.logger?.info("Connection closed");
+      }
+    });
+  }
+
+  async waitForMaybeReadyWebSocket(): Promise<boolean> {
+    if (this.wsClient === undefined) {
+      await this.createWebSocket();
+    }
+
+    while (
+      this.wsClient !== undefined &&
+      this.wsClient.readyState !== this.wsClient.OPEN
+    ) {
+      await sleep(10);
+    }
+
+    if (this.wsClient !== undefined) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  private async restartClosedWebsocket() {
+    if (this.wsClosed === true) {
+      return;
+    }
+    await this.waitForMaybeReadyWebSocket();
+
+    if (this.wsClient === undefined) {
+      this.logger?.error(
+        "Couldn't reconnect to websocket. Error callback is called."
+      );
+      return;
+    }
+
+    const message: ClientMessage = {
+      ids: Array.from(this.priceFeedCallbacks.keys()),
+      type: "subscribe",
+    };
+
+    this.logger?.info("Subscribing existing price feeds");
+    this.wsClient.send(JSON.stringify(message));
+  }
+
+  async subscribePriceFeedUpdate(
+    priceIds: HexString[],
+    cb: PriceFeedUpdateCallback
+  ) {
+    await this.waitForMaybeReadyWebSocket();
+
+    let newPriceIds: HexString[] = [];
+
+    for (let id of priceIds) {
+      if (!this.priceFeedCallbacks.has(id)) {
+        this.priceFeedCallbacks.set(id, new Set());
+        newPriceIds.push(id);
+      }
+
+      this.priceFeedCallbacks.get(id)!.add(cb);
+    }
+
+    const message: ClientMessage = {
+      ids: newPriceIds,
+      type: "subscribe",
+    };
+
+    if (this.wsClient === undefined) {
+      this.logger?.error(
+        "Couldn't connect to websocket. Error callback is called. If websocket reconnects then it will be applied"
+      );
+    } else {
+      this.wsClient?.send(JSON.stringify(message));
+    }
+  }
+
+  async unsubscribePriceFeedUpdate(
+    priceIds: HexString[],
+    cb?: PriceFeedUpdateCallback
+  ) {
+    await this.waitForMaybeReadyWebSocket();
+
+    let removedPriceIds: HexString[] = [];
+
+    for (let id of priceIds) {
+      if (this.priceFeedCallbacks.has(id)) {
+        let idRemoved = false;
+
+        if (cb === undefined) {
+          this.priceFeedCallbacks.delete(id);
+          idRemoved = true;
+        } else {
+          this.priceFeedCallbacks.get(id)!.delete(cb);
+
+          if (this.priceFeedCallbacks.get(id)!.size === 0) {
+            this.priceFeedCallbacks.delete(id);
+            idRemoved = true;
+          }
+        }
+
+        if (idRemoved) {
+          removedPriceIds.push(id);
+        }
+      }
+    }
+
+    const message: ClientMessage = {
+      ids: removedPriceIds,
+      type: "unsubscribe",
+    };
+
+    if (this.wsClient === undefined) {
+      this.logger?.error(
+        "Couldn't connect to websocket. Error callback is called. If websocket reconnects then it will be applied"
+      );
+    } else {
+      this.wsClient?.send(JSON.stringify(message));
+    }
+  }
+
+  closeWebSocket() {
+    if (this.wsClient !== undefined) {
+      const client = this.wsClient;
+      this.wsClient = undefined;
+      client.close();
+    }
+    this.wsClosed = true;
+    this.priceFeedCallbacks.clear();
+  }
+}
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitExpoBackoff(attempts: number) {
+  await sleep(2 ** attempts * 100);
 }

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -130,7 +130,7 @@ export class PriceServiceConnection {
     cb: PriceFeedUpdateCallback
   ) {
     if (this.wsClient === undefined) {
-      throw new Error("WS is not started.");
+      await this.startWebSocket();
     }
 
     const newPriceIds: HexString[] = [];
@@ -157,7 +157,7 @@ export class PriceServiceConnection {
     cb?: PriceFeedUpdateCallback
   ) {
     if (this.wsClient === undefined) {
-      throw new Error("WS is not started.");
+      await this.startWebSocket();
     }
 
     const removedPriceIds: HexString[] = [];
@@ -189,7 +189,11 @@ export class PriceServiceConnection {
       type: "unsubscribe",
     };
 
-    this.wsClient?.send(JSON.stringify(message));
+    await this.wsClient?.send(JSON.stringify(message));
+
+    if (this.priceFeedCallbacks.size === 0) {
+      this.stopWebSocket();
+    }
   }
 
   async startWebSocket() {
@@ -265,9 +269,6 @@ export class PriceServiceConnection {
   }
 
   stopWebSocket() {
-    if (this.wsClient === undefined) {
-      throw new Error("WS Endpoint is not given hence Websocket is disabled.");
-    }
     this.wsClient?.closeWebSocket();
     this.wsClient = undefined;
     this.priceFeedCallbacks.clear();

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -125,7 +125,18 @@ export class PriceServiceConnection {
     return response.data;
   }
 
-  async subscribePriceFeedUpdate(
+  /**
+   * Subscribe to updates for given price ids.
+   *
+   * It will start a websocket connection if it's not started yet.
+   * Also, it won't throw any exception if given price ids are invalid or connection errors. Instead,
+   * it calls `connection.onWsError`. If you want to handle the errors you should set the
+   * `onWsError` function to your custom error handler.
+   *
+   * @param priceIds Array of hex-encoded price ids.
+   * @param cb Callback function that is called with a PriceFeed upon updates to given price ids.
+   */
+  async subscribePriceFeedUpdates(
     priceIds: HexString[],
     cb: PriceFeedUpdateCallback
   ) {
@@ -152,7 +163,18 @@ export class PriceServiceConnection {
     await this.wsClient?.send(JSON.stringify(message));
   }
 
-  async unsubscribePriceFeedUpdate(
+  /**
+   * Unsubscribe from updates for given price ids.
+   *
+   * It will close the websocket connection if it's not subscribed to any price feed updates anymore.
+   * Also, it won't throw any exception if given price ids are invalid or connection errors. Instead,
+   * it calls `connection.onWsError`. If you want to handle the errors you should set the
+   * `onWsError` function to your custom error handler.
+   *
+   * @param priceIds Array of hex-encoded price ids.
+   * @param cb Optional callback, if set it will only unsubscribe this callback from updates for given price ids.
+   */
+  async unsubscribePriceFeedUpdates(
     priceIds: HexString[],
     cb?: PriceFeedUpdateCallback
   ) {
@@ -192,10 +214,15 @@ export class PriceServiceConnection {
     await this.wsClient?.send(JSON.stringify(message));
 
     if (this.priceFeedCallbacks.size === 0) {
-      this.stopWebSocket();
+      this.closeWebSocket();
     }
   }
 
+  /**
+   * Starts connection websocket.
+   *
+   * This function is called automatically upon subscribing to price feed updates.
+   */
   async startWebSocket() {
     if (this.wsEndpoint === undefined) {
       throw new Error("Websocket endpoint is undefined.");
@@ -266,7 +293,14 @@ export class PriceServiceConnection {
     await this.wsClient.startWebSocket();
   }
 
-  stopWebSocket() {
+  /**
+   * Closes connection websocket.
+   *
+   * At termination, the websocket should be closed to finish the
+   * process elegantly. It will automatically close when the connection
+   * is subscribed to no price feeds.
+   */
+  closeWebSocket() {
     this.wsClient?.closeWebSocket();
     this.wsClient = undefined;
     this.priceFeedCallbacks.clear();

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -51,14 +51,14 @@ export class PriceServiceConnection {
   private wsClient: undefined | ResilientWebSocket;
   private wsEndpoint: undefined | string;
 
+  private logger: undefined | Logger;
+
   /**
    * Custom handler for web socket errors (connection and message parsing).
    *
    * Default handler only logs the errors.
    */
   onWsError: (error: Error) => void;
-
-  private logger: undefined | Logger;
 
   /**
    * Constructs a new Connection.

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -55,7 +55,7 @@ export class PriceServiceConnection {
   /**
    * Custom handler for web socket errors (connection and message parsing).
    *
-   * Default handler only logs the error and passes.
+   * Default handler only logs the errors.
    */
   onWsError: (error: Error) => any;
 

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -43,7 +43,7 @@ type ServerPriceUpdate = {
 
 type ServerMessage = ServerResponse | ServerPriceUpdate;
 
-export type PriceFeedUpdateCallback = (priceFeed: PriceFeed) => any;
+export type PriceFeedUpdateCallback = (priceFeed: PriceFeed) => void;
 
 export class PriceServiceConnection {
   private httpClient: AxiosInstance;
@@ -57,7 +57,7 @@ export class PriceServiceConnection {
    *
    * Default handler only logs the errors.
    */
-  onWsError: (error: Error) => any;
+  onWsError: (error: Error) => void;
 
   private logger: undefined | Logger;
 

--- a/pyth-common-js/src/ResillientWebSocket.ts
+++ b/pyth-common-js/src/ResillientWebSocket.ts
@@ -9,7 +9,7 @@ export class ResilientWebSocket {
   private pingTimeout: any; // Node and browser have different implementations
   private logger: undefined | Logger;
 
-  onWsError: (error: Error) => any;
+  onError: (error: Error) => any;
   onMessage: (data: WebSocket.RawData, isBinary: boolean) => void;
   onReconnect: () => any;
 
@@ -18,7 +18,7 @@ export class ResilientWebSocket {
     this.logger = logger;
 
     this.wsFailedAttempts = 0;
-    this.onWsError = (error: Error) => {
+    this.onError = (error: Error) => {
       this.logger?.error(error);
     };
     this.wsUserClosed = true;
@@ -55,7 +55,7 @@ export class ResilientWebSocket {
       this.heartbeat();
     });
 
-    this.wsClient.on("error", this.onWsError);
+    this.wsClient.on("error", this.onError);
 
     this.wsClient.on("message", this.onMessage);
 

--- a/pyth-common-js/src/ResillientWebSocket.ts
+++ b/pyth-common-js/src/ResillientWebSocket.ts
@@ -9,9 +9,9 @@ export class ResilientWebSocket {
   private pingTimeout: undefined | NodeJS.Timeout;
   private logger: undefined | Logger;
 
-  onError: (error: Error) => any;
+  onError: (error: Error) => void;
   onMessage: (data: WebSocket.Data) => void;
-  onReconnect: () => any;
+  onReconnect: () => void;
 
   constructor(endpoint: string, logger?: Logger) {
     this.endpoint = endpoint;

--- a/pyth-common-js/src/ResillientWebSocket.ts
+++ b/pyth-common-js/src/ResillientWebSocket.ts
@@ -3,6 +3,16 @@ import { Logger } from "ts-log";
 
 const PING_TIMEOUT_DURATION = 30000 + 3000; // It is 30s on the server and 3s is added for delays
 
+/**
+ * This class wraps websocket to provide a resilient web socket client.
+ *
+ * It will reconnect if connection fails with exponential backoff. Also, in node, it will reconnect
+ * if it receives no ping request from server within a while as indication of timeout (assuming
+ * the server sends it regularly).
+ *
+ * This class also logs events if logger is given and by replacing onError method you can handle
+ * connection errors yourself (e.g: do not retry and close the connection).
+ */
 export class ResilientWebSocket {
   private endpoint: string;
   private wsClient: undefined | WebSocket;

--- a/pyth-common-js/src/ResillientWebSocket.ts
+++ b/pyth-common-js/src/ResillientWebSocket.ts
@@ -1,6 +1,8 @@
 import * as WebSocket from "isomorphic-ws";
 import { Logger } from "ts-log";
 
+const PING_TIMEOUT_DURATION = 30000 + 3000; // It is 30s on the server and 3s is added for delays
+
 export class ResilientWebSocket {
   private endpoint: string;
   private wsClient: undefined | WebSocket;
@@ -33,7 +35,7 @@ export class ResilientWebSocket {
 
     if (this.wsClient === undefined) {
       this.logger?.error(
-        "Couldn't connect to websocket. Error callback is called."
+        "Couldn't connect to the websocket server. Error callback is called."
       );
     } else {
       this.wsClient?.send(data);
@@ -77,7 +79,7 @@ export class ResilientWebSocket {
         const waitTime = expoBackoff(this.wsFailedAttempts);
 
         this.logger?.error(
-          `Connection closed unexpected or because of timeout. Reconnecting after ${waitTime}ms.`
+          `Connection closed unexpectedly or because of timeout. Reconnecting after ${waitTime}ms.`
         );
 
         await sleep(waitTime);
@@ -107,10 +109,10 @@ export class ResilientWebSocket {
 
     this.pingTimeout = setTimeout(() => {
       console.log(this);
-      this.logger?.warn(`Websocket timed out. Restarting websocket.`);
+      this.logger?.warn(`Websocket connection timed out. Reconnecting...`);
       this.wsClient?.terminate();
       this.restartUnexpectedClosedWebsocket();
-    }, 30000 + 3000); // Assumes server pings every 30 seconds.
+    }, PING_TIMEOUT_DURATION);
   }
 
   private async waitForMaybeReadyWebSocket() {

--- a/pyth-common-js/src/ResillientWebSocket.ts
+++ b/pyth-common-js/src/ResillientWebSocket.ts
@@ -1,0 +1,139 @@
+import * as WebSocket from "isomorphic-ws";
+import { Logger } from "ts-log";
+
+export class ResilientWebSocket {
+  private endpoint: string;
+  private wsClient: undefined | WebSocket;
+  private wsUserClosed: boolean;
+  private wsFailedAttempts: number;
+  private pingTimeout: any; // Node and browser have different implementations
+  private logger: undefined | Logger;
+
+  onWsError: (error: Error) => any;
+  onMessage: (data: WebSocket.RawData, isBinary: boolean) => void;
+  onReconnect: () => any;
+
+  constructor(endpoint: string, logger?: Logger) {
+    this.endpoint = endpoint;
+    this.logger = logger;
+
+    this.wsFailedAttempts = 0;
+    this.onWsError = (error: Error) => {
+      this.logger?.error(error);
+    };
+    this.wsUserClosed = true;
+    this.onMessage = () => {};
+    this.onReconnect = () => {};
+  }
+
+  async send(data: any) {
+    this.logger?.info(`Sending ${data}`);
+
+    await this.waitForMaybeReadyWebSocket();
+
+    if (this.wsClient === undefined) {
+      this.logger?.error(
+        "Couldn't connect to websocket. Error callback is called. If websocket reconnects then it will be applied"
+      );
+    } else {
+      this.wsClient?.send(data);
+    }
+  }
+
+  async startWebSocket() {
+    if (this.wsClient !== undefined) {
+      return;
+    }
+
+    this.logger?.info(`Creating Web Socket client`);
+
+    this.wsClient = new WebSocket(this.endpoint);
+    this.wsUserClosed = false;
+
+    this.wsClient.on("open", () => {
+      this.wsFailedAttempts = 0;
+      this.heartbeat();
+    });
+
+    this.wsClient.on("error", this.onWsError);
+
+    this.wsClient.on("message", this.onMessage);
+
+    this.wsClient.on("ping", this.heartbeat.bind(this));
+
+    this.wsClient.on("close", async () => {
+      clearInterval(this.pingTimeout);
+      if (this.wsUserClosed === false) {
+        this.wsFailedAttempts += 1;
+        this.wsClient = undefined;
+        const waitTime = expoBackoff(this.wsFailedAttempts);
+
+        this.logger?.error(
+          `Connection closed unexpected or because of timeout. Reconnecting after ${waitTime}ms.`
+        );
+
+        await sleep(waitTime);
+        this.restartUnexpectedClosedWebsocket();
+      } else {
+        this.logger?.info("Connection closed");
+      }
+    });
+  }
+
+  private heartbeat() {
+    this.logger?.info("Heartbeat");
+
+    clearTimeout(this.pingTimeout);
+
+    this.pingTimeout = setTimeout(() => {
+      console.log(this);
+      this.logger?.warn(`Websocket timed out. Restarting websocket.`);
+      this.wsClient?.terminate();
+      this.restartUnexpectedClosedWebsocket();
+    }, 30000 + 3000); // Assumes server pings every 30 seconds.
+  }
+
+  private async waitForMaybeReadyWebSocket() {
+    while (
+      this.wsClient !== undefined &&
+      this.wsClient.readyState !== this.wsClient.OPEN
+    ) {
+      await sleep(10);
+    }
+  }
+
+  private async restartUnexpectedClosedWebsocket() {
+    if (this.wsUserClosed === true) {
+      return;
+    }
+
+    await this.startWebSocket();
+    await this.waitForMaybeReadyWebSocket();
+
+    if (this.wsClient === undefined) {
+      this.logger?.error(
+        "Couldn't reconnect to websocket. Error callback is called."
+      );
+      return;
+    }
+
+    this.onReconnect();
+  }
+
+  closeWebSocket() {
+    if (this.wsClient !== undefined) {
+      const client = this.wsClient;
+      this.wsClient = undefined;
+      client.close();
+    }
+    this.wsUserClosed = true;
+  }
+}
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function expoBackoff(attempts: number): number {
+  return 2 ** attempts * 100;
+}

--- a/pyth-common-js/src/ResillientWebSocket.ts
+++ b/pyth-common-js/src/ResillientWebSocket.ts
@@ -62,7 +62,7 @@ export class ResilientWebSocket {
     this.wsClient = new WebSocket(this.endpoint);
     this.wsUserClosed = false;
 
-    this.wsClient.onopen = (_event) => {
+    this.wsClient.onopen = () => {
       this.wsFailedAttempts = 0;
       // Ping handler is undefined in browser side so heartbeat is disabled.
       if (this.wsClient!.on !== undefined) {
@@ -78,7 +78,7 @@ export class ResilientWebSocket {
       this.onMessage(event.data);
     };
 
-    this.wsClient.onclose = async (_event) => {
+    this.wsClient.onclose = async () => {
       if (this.pingTimeout !== undefined) {
         clearInterval(this.pingTimeout);
       }

--- a/pyth-common-js/src/ResillientWebSocket.ts
+++ b/pyth-common-js/src/ResillientWebSocket.ts
@@ -33,7 +33,7 @@ export class ResilientWebSocket {
 
     if (this.wsClient === undefined) {
       this.logger?.error(
-        "Couldn't connect to websocket. Error callback is called. If websocket reconnects then it will be applied"
+        "Couldn't connect to websocket. Error callback is called."
       );
     } else {
       this.wsClient?.send(data);
@@ -80,6 +80,11 @@ export class ResilientWebSocket {
     });
   }
 
+  /**
+   * This approach only works when server constantly pings the clients.
+   * Otherwise you might consider sending ping and acting on pong responses
+   * yourself.
+   */
   private heartbeat() {
     this.logger?.info("Heartbeat");
 

--- a/pyth-common-js/src/ResillientWebSocket.ts
+++ b/pyth-common-js/src/ResillientWebSocket.ts
@@ -85,7 +85,7 @@ export class ResilientWebSocket {
         await sleep(waitTime);
         this.restartUnexpectedClosedWebsocket();
       } else {
-        this.logger?.info("Connection closed");
+        this.logger?.info("The connection has been closed successfully.");
       }
     };
 
@@ -96,7 +96,10 @@ export class ResilientWebSocket {
   }
 
   /**
-   * This approach only works when server constantly pings the clients.
+   * Heartbeat is only enabled in node clients because they support handling
+   * ping-pong events.
+   *
+   * This approach only works when server constantly pings the clients which.
    * Otherwise you might consider sending ping and acting on pong responses
    * yourself.
    */
@@ -109,7 +112,7 @@ export class ResilientWebSocket {
 
     this.pingTimeout = setTimeout(() => {
       console.log(this);
-      this.logger?.warn(`Websocket connection timed out. Reconnecting...`);
+      this.logger?.warn(`Connection timed out. Reconnecting...`);
       this.wsClient?.terminate();
       this.restartUnexpectedClosedWebsocket();
     }, PING_TIMEOUT_DURATION);
@@ -130,6 +133,7 @@ export class ResilientWebSocket {
       }
     }
   }
+
   private async restartUnexpectedClosedWebsocket() {
     if (this.wsUserClosed === true) {
       return;

--- a/pyth-common-js/src/examples/PriceServiceClient.ts
+++ b/pyth-common-js/src/examples/PriceServiceClient.ts
@@ -38,11 +38,6 @@ async function run() {
     logger: console,
   });
 
-  connection.onWsError = (error) => {
-    console.log("Error:");
-    console.log(error);
-  };
-
   const priceIds = argv.priceIds as string[];
   const priceFeeds = await connection.getLatestPriceFeeds(priceIds);
   console.log(priceFeeds);

--- a/pyth-common-js/src/examples/PriceServiceClient.ts
+++ b/pyth-common-js/src/examples/PriceServiceClient.ts
@@ -10,7 +10,7 @@ function sleep(ms: number) {
 const argv = yargs(hideBin(process.argv))
   .option("endpoint", {
     description:
-      "Endpoint for the price service. e.g: https://endpoint/example",
+      "Endpoint URL for the price service. e.g: https://endpoint/example",
     type: "string",
     required: true,
   })

--- a/pyth-common-js/src/examples/PriceServiceClient.ts
+++ b/pyth-common-js/src/examples/PriceServiceClient.ts
@@ -46,8 +46,6 @@ async function run() {
   if (argv.ws !== undefined) {
     console.log("Subscribing to Price Feed updates");
 
-    await connection.startWebSocket();
-
     await connection.subscribePriceFeedUpdate(priceIds, (priceFeed) => {
       console.log(
         `Current price for ${priceFeed.id}: ${JSON.stringify(
@@ -58,10 +56,13 @@ async function run() {
 
     await sleep(600000);
 
+    // To close the websocket you should either unsubscribe from all updates
+    // or call stopWebSocket directly.
+
     console.log("Unsubscribing Price Feed updates");
     await connection.unsubscribePriceFeedUpdate(priceIds);
 
-    connection.stopWebSocket();
+    // await connection.stopWebSocket();
   }
 }
 

--- a/pyth-common-js/src/examples/PriceServiceClient.ts
+++ b/pyth-common-js/src/examples/PriceServiceClient.ts
@@ -44,13 +44,13 @@ async function run() {
   console.log(priceFeeds?.at(0)?.getCurrentPrice());
 
   if (argv.ws !== undefined) {
-    console.log("Subscribing to Price Feed updates");
+    console.log("Subscribing to price feed updates.");
 
     await connection.subscribePriceFeedUpdate(priceIds, (priceFeed) => {
       console.log(
         `Current price for ${priceFeed.id}: ${JSON.stringify(
           priceFeed.getCurrentPrice()
-        )}`
+        )}.`
       );
     });
 
@@ -59,7 +59,7 @@ async function run() {
     // To close the websocket you should either unsubscribe from all updates
     // or call stopWebSocket directly.
 
-    console.log("Unsubscribing Price Feed updates");
+    console.log("Unsubscribing from price feed updates.");
     await connection.unsubscribePriceFeedUpdate(priceIds);
 
     // await connection.stopWebSocket();

--- a/pyth-common-js/src/examples/PriceServiceClient.ts
+++ b/pyth-common-js/src/examples/PriceServiceClient.ts
@@ -14,7 +14,7 @@ const argv = yargs(hideBin(process.argv))
     type: "string",
     required: true,
   })
-  .option("wss", {
+  .option("ws", {
     description:
       "Web Socket endpoint for the Price service. e.g: wss://endpoint/example",
     type: "string",
@@ -34,7 +34,7 @@ const argv = yargs(hideBin(process.argv))
 async function run() {
   const connection = new PriceServiceConnection({
     httpEndpoint: argv.http,
-    wsEndpoint: argv.wss,
+    wsEndpoint: argv.ws,
     logger: console,
   });
 
@@ -43,7 +43,7 @@ async function run() {
   console.log(priceFeeds);
   console.log(priceFeeds?.at(0)?.getCurrentPrice());
 
-  if (argv.wss !== undefined) {
+  if (argv.ws !== undefined) {
     console.log("Subscribing to Price Feed updates");
 
     await connection.startWebSocket();

--- a/pyth-common-js/src/examples/PriceServiceClient.ts
+++ b/pyth-common-js/src/examples/PriceServiceClient.ts
@@ -34,7 +34,7 @@ const argv = yargs(hideBin(process.argv))
 async function run() {
   const connection = new PriceServiceConnection(argv.endpoint, {
     wsEndpoint: argv.wsEndpoint,
-    logger: console,
+    logger: console, // Providing logger will allow the connection to log it's events.
   });
 
   const priceIds = argv.priceIds as string[];

--- a/pyth-common-js/src/examples/PriceServiceClient.ts
+++ b/pyth-common-js/src/examples/PriceServiceClient.ts
@@ -46,6 +46,8 @@ async function run() {
   if (argv.wss !== undefined) {
     console.log("Subscribing to Price Feed updates");
 
+    await connection.startWebSocket();
+
     await connection.subscribePriceFeedUpdate(priceIds, (priceFeed) => {
       console.log(
         `Current price for ${priceFeed.id}: ${JSON.stringify(
@@ -59,7 +61,7 @@ async function run() {
     console.log("Unsubscribing Price Feed updates");
     await connection.unsubscribePriceFeedUpdate(priceIds);
 
-    connection.closeWebSocket();
+    connection.stopWebSocket();
   }
 }
 

--- a/pyth-common-js/src/examples/PriceServiceClient.ts
+++ b/pyth-common-js/src/examples/PriceServiceClient.ts
@@ -8,15 +8,15 @@ function sleep(ms: number) {
 }
 
 const argv = yargs(hideBin(process.argv))
-  .option("http", {
+  .option("endpoint", {
     description:
-      "HTTP endpoint for the Price service. e.g: https://endpoint/example",
+      "Endpoint for the price service. e.g: https://endpoint/example",
     type: "string",
     required: true,
   })
-  .option("ws", {
+  .option("wsEndpoint", {
     description:
-      "Web Socket endpoint for the Price service. e.g: wss://endpoint/example",
+      "Optional web socket endpoint for the price service if it's different than endpoint. e.g: wss://endpoint/example",
     type: "string",
     required: false,
   })
@@ -32,9 +32,8 @@ const argv = yargs(hideBin(process.argv))
   .parseSync();
 
 async function run() {
-  const connection = new PriceServiceConnection({
-    httpEndpoint: argv.http,
-    wsEndpoint: argv.ws,
+  const connection = new PriceServiceConnection(argv.endpoint, {
+    wsEndpoint: argv.wsEndpoint,
     logger: console,
   });
 
@@ -43,27 +42,25 @@ async function run() {
   console.log(priceFeeds);
   console.log(priceFeeds?.at(0)?.getCurrentPrice());
 
-  if (argv.ws !== undefined) {
-    console.log("Subscribing to price feed updates.");
+  console.log("Subscribing to price feed updates.");
 
-    await connection.subscribePriceFeedUpdates(priceIds, (priceFeed) => {
-      console.log(
-        `Current price for ${priceFeed.id}: ${JSON.stringify(
-          priceFeed.getCurrentPrice()
-        )}.`
-      );
-    });
+  await connection.subscribePriceFeedUpdates(priceIds, (priceFeed) => {
+    console.log(
+      `Current price for ${priceFeed.id}: ${JSON.stringify(
+        priceFeed.getCurrentPrice()
+      )}.`
+    );
+  });
 
-    await sleep(600000);
+  await sleep(600000);
 
-    // To close the websocket you should either unsubscribe from all
-    // price feeds or call `connection.stopWebSocket()` directly.
+  // To close the websocket you should either unsubscribe from all
+  // price feeds or call `connection.stopWebSocket()` directly.
 
-    console.log("Unsubscribing from price feed updates.");
-    await connection.unsubscribePriceFeedUpdates(priceIds);
+  console.log("Unsubscribing from price feed updates.");
+  await connection.unsubscribePriceFeedUpdates(priceIds);
 
-    // connection.closeWebSocket();
-  }
+  // connection.closeWebSocket();
 }
 
 run();

--- a/pyth-common-js/src/examples/PriceServiceClient.ts
+++ b/pyth-common-js/src/examples/PriceServiceClient.ts
@@ -46,7 +46,7 @@ async function run() {
   if (argv.ws !== undefined) {
     console.log("Subscribing to price feed updates.");
 
-    await connection.subscribePriceFeedUpdate(priceIds, (priceFeed) => {
+    await connection.subscribePriceFeedUpdates(priceIds, (priceFeed) => {
       console.log(
         `Current price for ${priceFeed.id}: ${JSON.stringify(
           priceFeed.getCurrentPrice()
@@ -56,13 +56,13 @@ async function run() {
 
     await sleep(600000);
 
-    // To close the websocket you should either unsubscribe from all updates
-    // or call stopWebSocket directly.
+    // To close the websocket you should either unsubscribe from all
+    // price feeds or call `connection.stopWebSocket()` directly.
 
     console.log("Unsubscribing from price feed updates.");
-    await connection.unsubscribePriceFeedUpdate(priceIds);
+    await connection.unsubscribePriceFeedUpdates(priceIds);
 
-    // await connection.stopWebSocket();
+    // connection.closeWebSocket();
   }
 }
 

--- a/pyth-common-js/src/utils.ts
+++ b/pyth-common-js/src/utils.ts
@@ -5,7 +5,7 @@
  * @returns Ws(s) protocol endpoint of the same address
  */
 export function makeWebsocketUrl(endpoint: string) {
-  let url = new URL(endpoint);
+  const url = new URL(endpoint);
   const useHttps = url.protocol === "https:";
 
   url.protocol = useHttps ? "wss:" : "ws:";

--- a/pyth-common-js/src/utils.ts
+++ b/pyth-common-js/src/utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Convert http(s) endpoint to ws(s) endpoint.
+ *
+ * @param endpoint Http(s) protocol endpoint
+ * @returns Ws(s) protocol endpoint of the same address
+ */
+export function makeWebsocketUrl(endpoint: string) {
+  let url = new URL(endpoint);
+  const useHttps = url.protocol === "https:";
+
+  url.protocol = useHttps ? "wss:" : "ws:";
+  url.host = "";
+
+  // Only shift the port by +1 as a convention for ws(s) only if given endpoint
+  // is explictly specifying the endpoint port (HTTP-based RPC), assuming
+  // we're directly trying to connect to solana-validator's ws listening port.
+  // When the endpoint omits the port, we're connecting to the protocol
+  // default ports: http(80) or https(443) and it's assumed we're behind a reverse
+  // proxy which manages WebSocket upgrade and backend port redirection.
+  if (url.port !== "") {
+    url.port = String(Number(url.port) + 1);
+  }
+  return url.toString();
+}


### PR DESCRIPTION
This adds WebSocket support the the clients. Changes to evm and terra clients (Readme + examples) come in a separate PR as they are using version dependency and this one needs to be published. 

In order to have a resilient connection another class is created that automatically reconnects to the server upon error with exponential backoff. It gets optional logger for logging purposes. Also it expects server pings and if it doesn't receive any within a fixed timeout it will reconnect.

It also exposes a method `onError` (`onWsError` in `PriceServiceConnection`) which people can override error handling (which only logs) and even stop the websocket if they want instead of reconnecting. 

Upon reconnection this client preserves the state and resubscribes. 

Alternatives:
Solana uses rpc-websockets (which is based on json-rpc) and we thought it's overkill for our simple websocket. So the server is implemented in plain WebSocket. After finishing this code I looked at their code again and apparently rpc-websockets handles reconnection as well. However it doesn't provide logging and custom error handling. I didn't rewrite it because my work was done and this change requires changing server code again. Almost the same argument about Socket.IO.

One exchange websocket api kind of proxied ws and said they won't handle any error and it's up to users to do it. Although it was easier I decided to keep resiliency because most of people probably won't bother to handle it.
