### PR TITLE
Fix leading 0x in websocket logic

### DIFF
--- a/pyth-common-js/package-lock.json
+++ b/pyth-common-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-common-js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-common-js",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/pyth-sdk-js": "^0.1.0",

--- a/pyth-common-js/package.json
+++ b/pyth-common-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-common-js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pyth Network Common Utils in JS",
   "author": {
     "name": "Pyth Data Association"

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -4,7 +4,7 @@ import axiosRetry from "axios-retry";
 import * as WebSocket from "isomorphic-ws";
 import { Logger } from "ts-log";
 import { ResilientWebSocket } from "./ResillientWebSocket";
-import { makeWebsocketUrl } from "./utils";
+import { makeWebsocketUrl, removeLeading0xIfExists } from "./utils";
 
 export type DurationInMs = number;
 
@@ -147,6 +147,8 @@ export class PriceServiceConnection {
       await this.startWebSocket();
     }
 
+    priceIds = priceIds.map((priceId) => removeLeading0xIfExists(priceId));
+
     const newPriceIds: HexString[] = [];
 
     for (const id of priceIds) {
@@ -184,6 +186,8 @@ export class PriceServiceConnection {
     if (this.wsClient === undefined) {
       await this.startWebSocket();
     }
+
+    priceIds = priceIds.map((priceId) => removeLeading0xIfExists(priceId));
 
     const removedPriceIds: HexString[] = [];
 

--- a/pyth-common-js/src/utils.ts
+++ b/pyth-common-js/src/utils.ts
@@ -1,3 +1,5 @@
+import { HexString } from "@pythnetwork/pyth-sdk-js";
+
 /**
  * Convert http(s) endpoint to ws(s) endpoint.
  *
@@ -11,4 +13,12 @@ export function makeWebsocketUrl(endpoint: string) {
   url.protocol = useHttps ? "wss:" : "ws:";
 
   return url.toString();
+}
+
+export function removeLeading0xIfExists(id: HexString): HexString {
+  if (id.startsWith("0x")) {
+    return id.substring(2);
+  } else {
+    return id;
+  }
 }


### PR DESCRIPTION
Before this change, when the websocket received a new price feed update it matched the data id (without leading 0x) with a mapping of ids (possibly with leading 0x) to callbacks in order to call the callbacks. So a subscription with an id with leading 0x wouldn't work. 

This will remove the leading 0x if exists in the beginning of processing price ids in sub/unsub calls to fix this problem.

Also bumps the version to 0.4.0.