### PR TITLE
Fix ws 0x bug: add new version in evm and terra packages

### DIFF
--- a/pyth-evm-js/package-lock.json
+++ b/pyth-evm-js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@pythnetwork/pyth-evm-js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-evm-js",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@pythnetwork/pyth-common-js": "^0.3.0"
+        "@pythnetwork/pyth-common-js": "^0.4.0"
       },
       "devDependencies": {
         "@truffle/hdwallet-provider": "^2.0.8",
@@ -1642,9 +1642,9 @@
       }
     },
     "node_modules/@pythnetwork/pyth-common-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-0.3.0.tgz",
-      "integrity": "sha512-CCrgg6dQlP3WryeJyAZWuTTpBQz224ghvgTlYwWgaB+cvKh4uQdD6l9/r2yYkxkLUnpUVazOEpx7+UZQKLX/RQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-0.4.0.tgz",
+      "integrity": "sha512-V/IVJCypr+YalWmWxcLMvlXuSUkX/yGHyoXA7doOP71J1F1WmtpGs3Woie6iqhZxyJctckVabFnKgcMYjQ03Eg==",
       "dependencies": {
         "@pythnetwork/pyth-sdk-js": "^0.1.0",
         "@types/ws": "^8.5.3",
@@ -12398,9 +12398,9 @@
       }
     },
     "@pythnetwork/pyth-common-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-0.3.0.tgz",
-      "integrity": "sha512-CCrgg6dQlP3WryeJyAZWuTTpBQz224ghvgTlYwWgaB+cvKh4uQdD6l9/r2yYkxkLUnpUVazOEpx7+UZQKLX/RQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-0.4.0.tgz",
+      "integrity": "sha512-V/IVJCypr+YalWmWxcLMvlXuSUkX/yGHyoXA7doOP71J1F1WmtpGs3Woie6iqhZxyJctckVabFnKgcMYjQ03Eg==",
       "requires": {
         "@pythnetwork/pyth-sdk-js": "^0.1.0",
         "@types/ws": "^8.5.3",

--- a/pyth-evm-js/package.json
+++ b/pyth-evm-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-evm-js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Pyth Network EVM Utils in JS",
   "homepage": "https://pyth.network",
   "author": {
@@ -48,6 +48,6 @@
     "yargs": "^17.4.1"
   },
   "dependencies": {
-    "@pythnetwork/pyth-common-js": "^0.3.0"
+    "@pythnetwork/pyth-common-js": "^0.4.0"
   }
 }

--- a/pyth-terra-js/package-lock.json
+++ b/pyth-terra-js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@pythnetwork/pyth-terra-js",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-terra-js",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@pythnetwork/pyth-common-js": "^0.3.0",
+        "@pythnetwork/pyth-common-js": "^0.4.0",
         "@terra-money/terra.js": "^3.0.11",
         "axios": "^0.26.1"
       },
@@ -1089,9 +1089,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@pythnetwork/pyth-common-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-0.3.0.tgz",
-      "integrity": "sha512-CCrgg6dQlP3WryeJyAZWuTTpBQz224ghvgTlYwWgaB+cvKh4uQdD6l9/r2yYkxkLUnpUVazOEpx7+UZQKLX/RQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-0.4.0.tgz",
+      "integrity": "sha512-V/IVJCypr+YalWmWxcLMvlXuSUkX/yGHyoXA7doOP71J1F1WmtpGs3Woie6iqhZxyJctckVabFnKgcMYjQ03Eg==",
       "dependencies": {
         "@pythnetwork/pyth-sdk-js": "^0.1.0",
         "@types/ws": "^8.5.3",
@@ -6594,9 +6594,9 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@pythnetwork/pyth-common-js": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-0.3.0.tgz",
-      "integrity": "sha512-CCrgg6dQlP3WryeJyAZWuTTpBQz224ghvgTlYwWgaB+cvKh4uQdD6l9/r2yYkxkLUnpUVazOEpx7+UZQKLX/RQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-0.4.0.tgz",
+      "integrity": "sha512-V/IVJCypr+YalWmWxcLMvlXuSUkX/yGHyoXA7doOP71J1F1WmtpGs3Woie6iqhZxyJctckVabFnKgcMYjQ03Eg==",
       "requires": {
         "@pythnetwork/pyth-sdk-js": "^0.1.0",
         "@types/ws": "^8.5.3",

--- a/pyth-terra-js/package.json
+++ b/pyth-terra-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-terra-js",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Pyth Network Terra Utils in JS",
   "homepage": "https://pyth.network",
   "author": {
@@ -43,7 +43,7 @@
     "yargs": "^17.4.1"
   },
   "dependencies": {
-    "@pythnetwork/pyth-common-js": "^0.3.0",
+    "@pythnetwork/pyth-common-js": "^0.4.0",
     "@terra-money/terra.js": "^3.0.11",
     "axios": "^0.26.1"
   }


### PR DESCRIPTION
Only updates pyth-common-js version and bump version