### PR TITLE
Add link to pyth-aptos-js package on pyth-js README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Please see the [pyth.network documentation](https://docs.pyth.network/) for more
 ## Usage
 
 - The [pyth-evm-js](./pyth-evm-js/) package can be used to consume Pyth price feeds on EVM-based networks.
+- The [pyth-aptos-js](./pyth-aptos-js/) package can be used to consume Pyth price feeds on the Aptos networks.
 - The [pyth-terra-js](./pyth-terra-js/) package can be used to consume Pyth price feeds on the Terra network.
 
 ## Development


### PR DESCRIPTION
Adds an entry-point to the Pyth Aptos JS package