### PR TITLE
Expose separate functions for fetching and serialization

### DIFF
--- a/pyth-aptos-js/src/AptosPriceServiceConnection.ts
+++ b/pyth-aptos-js/src/AptosPriceServiceConnection.ts
@@ -7,7 +7,7 @@ export class AptosPriceServiceConnection extends PriceServiceConnection {
    * This will throw an axios error if there is a network problem or the price service returns a non-ok response (e.g: Invalid price ids)
    *
    * @param priceIds Array of hex-encoded price ids.
-   * @returns Array of price update data, serialized such that it can be passed to the Pyth Aptos contract.
+   * @returns Array of price update data.
    */
   async getPriceFeedsUpdateData(priceIds: HexString[]): Promise<number[][]> {
     // Fetch the latest price feed update VAAs from the price service

--- a/pyth-aptos-js/src/AptosPriceServiceConnection.ts
+++ b/pyth-aptos-js/src/AptosPriceServiceConnection.ts
@@ -9,16 +9,21 @@ export class AptosPriceServiceConnection extends PriceServiceConnection {
    * @param priceIds Array of hex-encoded price ids.
    * @returns Array of price update data, serialized such that it can be passed to the Pyth Aptos contract.
    */
-  async getPriceFeedsUpdateData(priceIds: HexString[]): Promise<Uint8Array> {
+  async getPriceFeedsUpdateData(priceIds: HexString[]): Promise<number[][]> {
     // Fetch the latest price feed update VAAs from the price service
     const latestVaas = await this.getLatestVaas(priceIds);
+    return latestVaas.map((vaa) => Array.from(Buffer.from(vaa, "base64")));
+  }
 
-    // Serialize the VAAs using BCS
+  /**
+   * Serializes the given updateData using BCS. Browser wallets typically automatically
+   * serialize the data, but this function can be used to manually serialize the update data
+   * if necessary.
+   */
+  static serializeUpdateData(updateData: number[][]): Uint8Array {
     const serializer = new BCS.Serializer();
-    serializer.serializeU32AsUleb128(latestVaas.length);
-    latestVaas.forEach((vaa) =>
-      serializer.serializeBytes(Buffer.from(vaa, "base64"))
-    );
+    serializer.serializeU32AsUleb128(updateData.length);
+    updateData.forEach((vaa) => serializer.serializeBytes(Buffer.from(vaa)));
     return serializer.getBytes();
   }
 }

--- a/pyth-aptos-js/src/examples/AptosRelay.ts
+++ b/pyth-aptos-js/src/examples/AptosRelay.ts
@@ -54,7 +54,7 @@ async function run() {
         argv.pythContract + "::pyth",
         "update_price_feeds_with_funder",
         [],
-        [priceFeedUpdateData]
+        [AptosPriceServiceConnection.serializeUpdateData(priceFeedUpdateData)]
       )
     )
   );


### PR DESCRIPTION
Some browser wallets (e.g. Petra) automatically serialize the payload, so we expose seperate functions for fetching and serializing.