### PR TITLE
Fix verbose bug.

### DIFF
--- a/pyth-common-js/package-lock.json
+++ b/pyth-common-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-common-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-common-js",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/pyth-sdk-js": "^1.0.0",

--- a/pyth-common-js/package.json
+++ b/pyth-common-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-common-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Pyth Network Common Utils in JS",
   "author": {
     "name": "Pyth Data Association"

--- a/pyth-common-js/src/PriceServiceConnection.ts
+++ b/pyth-common-js/src/PriceServiceConnection.ts
@@ -264,6 +264,7 @@ export class PriceServiceConnection {
         const message: ClientMessage = {
           ids: Array.from(this.priceFeedCallbacks.keys()),
           type: "subscribe",
+          verbose: this.verbose,
         };
 
         this.logger?.info("Resubscribing to existing price feeds.");


### PR DESCRIPTION
When PriceServiceConnection is initialized with verbose on, it should always call the price service with verbose flag. This PR fixes a bug that I forgot to set the verbose flag at one place (when the websocket tries to reconnect (after a failure)).

We should add tests for the client in the future.