### PR TITLE
Update pyth-sdk-js + bump to 1.2.0

### DIFF
--- a/pyth-common-js/package-lock.json
+++ b/pyth-common-js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@pythnetwork/pyth-common-js",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-common-js",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@pythnetwork/pyth-sdk-js": "^1.0.0",
+        "@pythnetwork/pyth-sdk-js": "^1.1.0",
         "@types/ws": "^8.5.3",
         "axios": "^0.26.1",
         "axios-retry": "^3.2.4",
@@ -1011,9 +1011,9 @@
       }
     },
     "node_modules/@pythnetwork/pyth-sdk-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.0.0.tgz",
-      "integrity": "sha512-nZ3tmn5EhR7Y6177cAE7p7iQJK40bipMUI4ZBwRhgTONOcg35jG0fsvlETZYgij0baQ1PMJQE6dIqZ50EMZpJw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.1.0.tgz",
+      "integrity": "sha512-IfZI/D+7HiA01TfzuA7Fh0SMhsE+hZWoI1pt48G+XMbNkXhiZG4lSQJRsnquSEY06YAFcAX2D66cFtV6BHy8IA=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -6014,9 +6014,9 @@
       }
     },
     "@pythnetwork/pyth-sdk-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.0.0.tgz",
-      "integrity": "sha512-nZ3tmn5EhR7Y6177cAE7p7iQJK40bipMUI4ZBwRhgTONOcg35jG0fsvlETZYgij0baQ1PMJQE6dIqZ50EMZpJw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.1.0.tgz",
+      "integrity": "sha512-IfZI/D+7HiA01TfzuA7Fh0SMhsE+hZWoI1pt48G+XMbNkXhiZG4lSQJRsnquSEY06YAFcAX2D66cFtV6BHy8IA=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/pyth-common-js/package.json
+++ b/pyth-common-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-common-js",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Pyth Network Common Utils in JS",
   "author": {
     "name": "Pyth Data Association"
@@ -41,7 +41,7 @@
     "yargs": "^17.4.1"
   },
   "dependencies": {
-    "@pythnetwork/pyth-sdk-js": "^1.0.0",
+    "@pythnetwork/pyth-sdk-js": "^1.1.0",
     "@types/ws": "^8.5.3",
     "axios": "^0.26.1",
     "axios-retry": "^3.2.4",

--- a/pyth-common-js/src/ResillientWebSocket.ts
+++ b/pyth-common-js/src/ResillientWebSocket.ts
@@ -121,7 +121,6 @@ export class ResilientWebSocket {
     }
 
     this.pingTimeout = setTimeout(() => {
-      console.log(this);
       this.logger?.warn(`Connection timed out. Reconnecting...`);
       this.wsClient?.terminate();
       this.restartUnexpectedClosedWebsocket();


### PR DESCRIPTION
This is following the sdk change adding price service receive time metadata to the price feed ([link](https://github.com/pyth-network/pyth-sdk-js/pull/9))