### PR TITLE
Point readmes to on-demand docs

### DIFF
--- a/pyth-aptos-js/README.md
+++ b/pyth-aptos-js/README.md
@@ -19,6 +19,7 @@ $ yarn add @pythnetwork/pyth-aptos-js
 ## Quickstart
 
 Pyth stores prices off-chain to minimize gas fees, which allows us to offer a wider selection of products and faster update times.
+See [On-Demand Updates](https://docs.pyth.network/consume-data/on-demand) for more information about this approach.
 To use Pyth prices on chain,
 they must be fetched from an off-chain price service. The `AptosPriceServiceConnection` class can be used to interact with these services,
 providing a way to fetch these prices directly in your code. The following example wraps an existing RPC provider and shows how to obtain
@@ -128,16 +129,6 @@ You can run this example with `npm run example-relay`. A full command that updat
 export APTOS_KEY = "0x...";
 npm run example-relay -- --endpoint https://xc-testnet.pyth.network --price-ids 0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b 0xca80ba6dc32e08d06f1aa886011eed1d77c77be9eb761cc10d72b7d0a2fd57a6 --full-node https://fullnode.testnet.aptoslabs.com/v1 --pyth-contract 0xaa706d631cde8c634fe1876b0c93e4dec69d0c6ccac30a734e9e257042e81541
 ```
-
-## How Pyth Works on Aptos
-
-Pyth prices are published on Pythnet, and relayed to Aptos using the [Wormhole Network](https://wormholenetwork.com/) as a cross-chain message passing bridge. The Wormhole Network observes when Pyth prices on Pythnet have changed and publishes an off-chain signed message attesting to this fact. This is explained in more detail [here](https://docs.wormholenetwork.com/wormhole/).
-
-This signed message can then be submitted to the Pyth contract on the Aptos networks, which will verify the Wormhole message and update the Pyth contract with the new price.
-
-### On-demand price updates
-
-Price updates are not submitted to the Aptos networks automatically: rather, when a consumer needs to use the value of a price they should first submit the latest Wormhole update for that price to the Pyth contract on the Aptos network they are working on. This will make the most recent price update available on-chain for Aptos contracts to use.
 
 ## Price Service endpoints
 

--- a/pyth-evm-js/README.md
+++ b/pyth-evm-js/README.md
@@ -19,7 +19,7 @@ $ yarn add @pythnetwork/pyth-evm-js
 ## Quickstart
 
 Pyth stores prices off-chain to minimize gas fees, which allows us to offer a wider selection of products and faster update times.
-See [How Pyth Works in EVM](#how-pyth-works-in-evm) for more details about this approach. In order to use Pyth prices on chain,
+See [On-Demand Updates](https://docs.pyth.network/consume-data/on-demand) for more information about this approach. In order to use Pyth prices on chain,
 they must be fetched from an off-chain price service. The `EvmPriceServiceConnection` class can be used to interact with these services,
 providing a way to fetch these prices directly in your code. The following example wraps an existing RPC provider and shows how to obtain
 Pyth prices and submit them to the network:
@@ -145,16 +145,6 @@ You can run this example with `npm run example-relay`. A full command that updat
 ```bash
 npm run example-relay -- --network bnb_testnet --mnemonic "my good mnemonic" --endpoint https://xc-testnet.pyth.network --price-ids 0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b 0xca80ba6dc32e08d06f1aa886011eed1d77c77be9eb761cc10d72b7d0a2fd57a6
 ```
-
-## How Pyth Works on EVM Chains
-
-Pyth prices are published on Pythnet, and relayed to EVM chains using the [Wormhole Network](https://wormholenetwork.com/) as a cross-chain message passing bridge. The Wormhole Network observes when Pyth prices on Pythnet have changed and publishes an off-chain signed message attesting to this fact. This is explained in more detail [here](https://docs.wormholenetwork.com/wormhole/).
-
-This signed message can then be submitted to the Pyth contract on the EVM networks, which will verify the Wormhole message and update the Pyth contract with the new price.
-
-### On-demand price updates
-
-Price updates are not submitted on the EVM networks automatically: rather, when a consumer needs to use the value of a price they should first submit the latest Wormhole update for that price to the Pyth contract on the EVM network they are working on. This will make the most recent price update available on-chain for EVM contracts to use.
 
 ## Price Service endpoints
 


### PR DESCRIPTION
We have a full description of the on-demand model in gitbook now, so point everyone to that instead of rehashing in the readme.