### PR TITLE
[pyth-evm-price-pusher]: Enable polling in evm WS RPC

### DIFF
--- a/pyth-evm-price-pusher/README.md
+++ b/pyth-evm-price-pusher/README.md
@@ -62,10 +62,11 @@ docker run public.ecr.aws/pyth-network/xc-evm-price-pusher:v<version> -- <above-
 
 The program accepts the following command line arguments:
 
-- `evm-endpoint`: RPC endpoint URL for the EVM network. If you provide a websocket RPC endpoint (`ws[s]://...`),
-  the price pusher will use event subscriptions to read the current EVM price. If you provide a normal
-  HTTP endpoint, the pusher will periodically poll for updates. The polling interval is configurable via
-  the `evm-polling-frequency` command-line argument (described below).
+- `evm-endpoint`: RPC endpoint URL for the EVM network. If you provide a normal HTTP endpoint,
+  the pusher will periodically poll for updates. The polling interval is configurable via the
+  `evm-polling-frequency` command-line argument (described below). If you provide a websocket RPC endpoint
+  (`ws[s]://...`), the price pusher will use event subscriptions to read the current EVM
+  price in addition to polling.
 - `mnemonic-file`: Path to payer mnemonic (private key) file.
 - `pyth-contract`: The Pyth contract address. Provide the network name on which Pyth is deployed
   or the Pyth contract address if you use a local network.

--- a/pyth-evm-price-pusher/docker-compose.mainnet.sample.yaml
+++ b/pyth-evm-price-pusher/docker-compose.mainnet.sample.yaml
@@ -1,6 +1,6 @@
 services:
   spy:
-    image: ghcr.io/wormhole-foundation/guardiand:v2.10.3
+    image: ghcr.io/wormhole-foundation/guardiand:v2.13.1
     command:
       - "spy"
       - "--nodeKey"

--- a/pyth-evm-price-pusher/docker-compose.testnet.sample.yaml
+++ b/pyth-evm-price-pusher/docker-compose.testnet.sample.yaml
@@ -1,6 +1,6 @@
 services:
   spy:
-    image: ghcr.io/wormhole-foundation/guardiand:v2.10.3
+    image: ghcr.io/wormhole-foundation/guardiand:v2.13.1
     command:
       - "spy"
       - "--nodeKey"

--- a/pyth-evm-price-pusher/package-lock.json
+++ b/pyth-evm-price-pusher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-evm-price-pusher",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-evm-price-pusher",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/pyth-evm-js": "^1.0.0",

--- a/pyth-evm-price-pusher/package.json
+++ b/pyth-evm-price-pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-evm-price-pusher",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Pyth EVM Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/pyth-evm-price-pusher/src/evm-price-listener.ts
+++ b/pyth-evm-price-pusher/src/evm-price-listener.ts
@@ -54,15 +54,13 @@ export class EvmPriceListener implements PriceListener {
       this.startSubscription();
     } else {
       console.log(
-        "The target network RPC endpoint is not Websocket. Using polling instead..."
+        "The target network RPC endpoint is not Websocket. So only polling is used..."
       );
-      setInterval(this.pollPrices.bind(this), this.pollingFrequency * 1000);
     }
 
-    // Poll the prices to have values in the beginning until updates arrive.
-    console.log(
-      "Polling the prices in the beginning in order to set the initial values."
-    );
+    console.log(`Polling the prices every ${this.pollingFrequency} seconds...`);
+    setInterval(this.pollPrices.bind(this), this.pollingFrequency * 1000);
+
     await this.pollPrices();
   }
 
@@ -134,7 +132,7 @@ export class EvmPriceListener implements PriceListener {
     return {
       conf: priceRaw.conf,
       price: priceRaw.price,
-      publishTime: priceRaw.publishTime,
+      publishTime: Number(priceRaw.publishTime),
     };
   }
 }

--- a/pyth-evm-price-pusher/src/index.ts
+++ b/pyth-evm-price-pusher/src/index.ts
@@ -15,10 +15,11 @@ import { readPriceConfigFile } from "./price-config";
 const argv = yargs(hideBin(process.argv))
   .option("evm-endpoint", {
     description:
-      "RPC endpoint URL for the EVM network. If you provide a websocket RPC endpoint (`ws[s]://...`), " +
-      "the price pusher will use event subscriptions to read the current EVM price. If you provide " +
-      "a normal HTTP endpoint, the pusher will periodically poll for updates. The polling interval " +
-      "is configurable via the `evm-polling-frequency` command-line argument",
+      "RPC endpoint URL for the EVM network. If you provide a normal HTTP endpoint, the pusher " +
+      "will periodically poll for updates. The polling interval is configurable via the " +
+      "`evm-polling-frequency` command-line argument. If you provide a websocket RPC " +
+      "endpoint (`ws[s]://...`), the price pusher will use event subscriptions to read " +
+      "the current EVM price in addition to polling. ",
     type: "string",
     required: true,
   })

--- a/pyth-evm-price-pusher/src/pusher.ts
+++ b/pyth-evm-price-pusher/src/pusher.ts
@@ -201,6 +201,9 @@ export class Pusher {
 
     console.log(`Analyzing price ${priceConfig.alias} (${priceId})`);
 
+    console.log("Source latest price: ", sourceLatestPrice);
+    console.log("Target latest price: ", targetLatestPrice);
+
     console.log(
       `Time difference: ${timeDifference} (< ${priceConfig.timeDifference}?)`
     );


### PR DESCRIPTION
Prior to this PR, if a websocket RPC is provided the code only listens to the events. If the RPC misses some events, there is a chance of deadlock in the code:

The price pusher thinks the price on target chain is at time 10, then imagine the price is updated to time 12 and price pusher does not get the event for it. Then upon updating the price at time 15, the pusher tells `updatePriceIfNecessary` that don't update the price if the price is updated after time 10. And hence, the update gets rejected and this will happen over and over again. 

The pusher provides the value 11, instead of 15 to the `updatePriceIfNecessary` as a further gas optimization. Because, the pusher triggered a push based on assuming the target chain price is at time 10 (and not later). For example, if it gets updated to time 13, the trigger condition might not hold anymore and it can reject faster.