### PR TITLE
Update solidity-sdk version and its usages

### DIFF
--- a/pyth-evm-js/README.md
+++ b/pyth-evm-js/README.md
@@ -46,9 +46,8 @@ const priceUpdateData = await connection.getPriceUpdateData(priceIds);
 // `pythContract` below is a web3.js contract; if you wish to use ethers, you need to change it accordingly.
 // You can find the Pyth interface ABI in @pythnetwork/pyth-sdk-solidity npm package.
 const updateFee = await pythContract.methods
-  .getUpdateFee(priceFeedUpdateData.length)
+  .getUpdateFee(priceFeedUpdateData)
   .call();
-
 // Calling someContract method
 // `someContract` below is a web3.js contract; if you wish to use ethers, you need to change it accordingly.
 await someContract.methods
@@ -73,7 +72,7 @@ contract SomeContract {
 
     function doSomething(uint someArg, string memory otherArg, bytes[] memory priceUpdateData) public payable {
         // Update the prices to be set to the latest values
-        uint fee = pyth.getUpdateFee(priceUpdateData.length);
+        uint fee = pyth.getUpdateFee(priceUpdateData);
         pyth.updatePriceFeeds{value: fee}(priceUpdateData);
 
         // Doing other things that uses prices

--- a/pyth-evm-js/package-lock.json
+++ b/pyth-evm-js/package-lock.json
@@ -13,7 +13,7 @@
         "buffer": "^6.0.3"
       },
       "devDependencies": {
-        "@pythnetwork/pyth-sdk-solidity": "^1.0.1",
+        "@pythnetwork/pyth-sdk-solidity": "^2.2.0",
         "@truffle/hdwallet-provider": "^2.0.8",
         "@types/ethereum-protocol": "^1.0.2",
         "@types/jest": "^27.4.1",
@@ -1683,9 +1683,9 @@
       "integrity": "sha512-nZ3tmn5EhR7Y6177cAE7p7iQJK40bipMUI4ZBwRhgTONOcg35jG0fsvlETZYgij0baQ1PMJQE6dIqZ50EMZpJw=="
     },
     "node_modules/@pythnetwork/pyth-sdk-solidity": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-1.0.1.tgz",
-      "integrity": "sha512-qcuDM1E8X6LNg+Eyq1WcwSpO0hWuQpDPb9YNG3GCR9NjaQObB0AlZ2ayLGtdUTc/yMm26haTtZyKx+9S+J6FWw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.2.0.tgz",
+      "integrity": "sha512-LsRMmaf9MTflGSymqOJMepFk/3R7DyxMOJfLDB5RDSieyiq+RJ5IYIYnXAFsMrqkjibOtVxARcortHtE9VWwhw==",
       "dev": true
     },
     "node_modules/@scure/base": {
@@ -12526,9 +12526,9 @@
       "integrity": "sha512-nZ3tmn5EhR7Y6177cAE7p7iQJK40bipMUI4ZBwRhgTONOcg35jG0fsvlETZYgij0baQ1PMJQE6dIqZ50EMZpJw=="
     },
     "@pythnetwork/pyth-sdk-solidity": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-1.0.1.tgz",
-      "integrity": "sha512-qcuDM1E8X6LNg+Eyq1WcwSpO0hWuQpDPb9YNG3GCR9NjaQObB0AlZ2ayLGtdUTc/yMm26haTtZyKx+9S+J6FWw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.2.0.tgz",
+      "integrity": "sha512-LsRMmaf9MTflGSymqOJMepFk/3R7DyxMOJfLDB5RDSieyiq+RJ5IYIYnXAFsMrqkjibOtVxARcortHtE9VWwhw==",
       "dev": true
     },
     "@scure/base": {

--- a/pyth-evm-js/package-lock.json
+++ b/pyth-evm-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-evm-js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-evm-js",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/pyth-common-js": "^1.0.0",

--- a/pyth-evm-js/package.json
+++ b/pyth-evm-js/package.json
@@ -30,7 +30,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
-    "@pythnetwork/pyth-sdk-solidity": "^1.0.1",
+    "@pythnetwork/pyth-sdk-solidity": "^2.2.0",
     "@truffle/hdwallet-provider": "^2.0.8",
     "@types/ethereum-protocol": "^1.0.2",
     "@types/jest": "^27.4.1",

--- a/pyth-evm-js/package.json
+++ b/pyth-evm-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-evm-js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Pyth Network EVM Utils in JS",
   "homepage": "https://pyth.network",
   "author": {

--- a/pyth-evm-js/src/examples/EvmRelay.ts
+++ b/pyth-evm-js/src/examples/EvmRelay.ts
@@ -115,7 +115,7 @@ async function run() {
   );
 
   const updateFee = await pythContract.methods
-    .getUpdateFee(priceFeedUpdateData.length)
+    .getUpdateFee(priceFeedUpdateData)
     .call();
   console.log(`Update fee: ${updateFee}`);
 

--- a/pyth-evm-price-pusher/package-lock.json
+++ b/pyth-evm-price-pusher/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/pyth-evm-js": "^1.0.0",
-        "@pythnetwork/pyth-sdk-solidity": "^1.0.1",
+        "@pythnetwork/pyth-sdk-solidity": "^2.2.0",
         "@truffle/hdwallet-provider": "^2.1.3",
         "joi": "^17.6.0",
         "web3": "^1.8.1",
@@ -1688,9 +1688,9 @@
       "integrity": "sha512-nZ3tmn5EhR7Y6177cAE7p7iQJK40bipMUI4ZBwRhgTONOcg35jG0fsvlETZYgij0baQ1PMJQE6dIqZ50EMZpJw=="
     },
     "node_modules/@pythnetwork/pyth-sdk-solidity": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-1.0.1.tgz",
-      "integrity": "sha512-qcuDM1E8X6LNg+Eyq1WcwSpO0hWuQpDPb9YNG3GCR9NjaQObB0AlZ2ayLGtdUTc/yMm26haTtZyKx+9S+J6FWw=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.2.0.tgz",
+      "integrity": "sha512-LsRMmaf9MTflGSymqOJMepFk/3R7DyxMOJfLDB5RDSieyiq+RJ5IYIYnXAFsMrqkjibOtVxARcortHtE9VWwhw=="
     },
     "node_modules/@scure/base": {
       "version": "1.1.1",
@@ -12526,9 +12526,9 @@
       "integrity": "sha512-nZ3tmn5EhR7Y6177cAE7p7iQJK40bipMUI4ZBwRhgTONOcg35jG0fsvlETZYgij0baQ1PMJQE6dIqZ50EMZpJw=="
     },
     "@pythnetwork/pyth-sdk-solidity": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-1.0.1.tgz",
-      "integrity": "sha512-qcuDM1E8X6LNg+Eyq1WcwSpO0hWuQpDPb9YNG3GCR9NjaQObB0AlZ2ayLGtdUTc/yMm26haTtZyKx+9S+J6FWw=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-solidity/-/pyth-sdk-solidity-2.2.0.tgz",
+      "integrity": "sha512-LsRMmaf9MTflGSymqOJMepFk/3R7DyxMOJfLDB5RDSieyiq+RJ5IYIYnXAFsMrqkjibOtVxARcortHtE9VWwhw=="
     },
     "@scure/base": {
       "version": "1.1.1",

--- a/pyth-evm-price-pusher/package-lock.json
+++ b/pyth-evm-price-pusher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-evm-price-pusher",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-evm-price-pusher",
-      "version": "1.0.3",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/pyth-evm-js": "^1.0.0",

--- a/pyth-evm-price-pusher/package.json
+++ b/pyth-evm-price-pusher/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@pythnetwork/pyth-evm-js": "^1.0.0",
-    "@pythnetwork/pyth-sdk-solidity": "^1.0.1",
+    "@pythnetwork/pyth-sdk-solidity": "^2.2.0",
     "@truffle/hdwallet-provider": "^2.1.3",
     "joi": "^17.6.0",
     "web3": "^1.8.1",

--- a/pyth-evm-price-pusher/package.json
+++ b/pyth-evm-price-pusher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-evm-price-pusher",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Pyth EVM Price Pusher",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/pyth-evm-price-pusher/src/evm-price-listener.ts
+++ b/pyth-evm-price-pusher/src/evm-price-listener.ts
@@ -1,17 +1,9 @@
 import { HexString } from "@pythnetwork/pyth-evm-js";
-
-import AbstractPythAbi from "@pythnetwork/pyth-sdk-solidity/abis/AbstractPyth.json";
-import Web3 from "web3";
 import { Contract, EventData } from "web3-eth-contract";
 import { PriceConfig } from "./price-config";
 import { PriceInfo, PriceListener } from "./price-listener";
 import { PythContractFactory } from "./pyth-contract-factory";
-import {
-  addLeading0x,
-  DurationInSeconds,
-  isWsEndpoint,
-  removeLeading0x,
-} from "./utils";
+import { addLeading0x, DurationInSeconds, removeLeading0x } from "./utils";
 
 export class EvmPriceListener implements PriceListener {
   private pythContractFactory: PythContractFactory;

--- a/pyth-evm-price-pusher/src/pusher.ts
+++ b/pyth-evm-price-pusher/src/pusher.ts
@@ -5,12 +5,8 @@ import {
 import { addLeading0x, DurationInSeconds, sleep } from "./utils";
 import { PriceInfo, PriceListener } from "./price-listener";
 import { Contract } from "web3-eth-contract";
-import AbstractPythAbi from "@pythnetwork/pyth-sdk-solidity/abis/AbstractPyth.json";
-import Web3 from "web3";
-import HDWalletProvider from "@truffle/hdwallet-provider";
 import { PriceConfig } from "./price-config";
 import { TransactionReceipt } from "ethereum-protocol";
-import { Provider } from "web3/providers";
 import { PythContractFactory } from "./pyth-contract-factory";
 
 export class Pusher {

--- a/pyth-evm-price-pusher/src/pusher.ts
+++ b/pyth-evm-price-pusher/src/pusher.ts
@@ -136,14 +136,6 @@ export class Pusher {
           throw err;
         }
 
-        if (err.message.includes("connection not open on send")) {
-          console.error(
-            "Web3 connection is closed. Recreating the connection and skipping this push."
-          );
-          this.pythContract =
-            this.pythContractFactory.createPythContractWithPayer();
-        }
-
         console.error("An unidentified error has occured:");
         console.error(receipt);
         throw err;

--- a/pyth-evm-price-pusher/src/pusher.ts
+++ b/pyth-evm-price-pusher/src/pusher.ts
@@ -113,11 +113,16 @@ export class Pusher {
       .on("error", (err: Error, receipt: TransactionReceipt) => {
         if (
           err.message.includes(
-            "no prices in the submitted batch have fresh prices, so this update will have no effect"
+            "VM Exception while processing transaction: revert"
           )
         ) {
+          // Since we are using custom error structs on solidity the rejection
+          // doesn't return any information why the call has reverted. Assuming that
+          // the update data is valid there is no possible rejection cause other than
+          // the target chain price being already updated.
           console.log(
-            "The target chain price has already updated, Skipping this push."
+            "Execution reverted. With high probablity, the target chain price " +
+              "has already updated, Skipping this push."
           );
           return;
         }

--- a/pyth-evm-price-pusher/src/pusher.ts
+++ b/pyth-evm-price-pusher/src/pusher.ts
@@ -96,7 +96,7 @@ export class Pusher {
     );
 
     const updateFee = await this.pythContract.methods
-      .getUpdateFee(priceFeedUpdateData.length)
+      .getUpdateFee(priceFeedUpdateData)
       .call();
     console.log(`Update fee: ${updateFee}`);
 


### PR DESCRIPTION
This PR updates `pyth-sdk-solidity` dependencies to the latest version. As this change is breaking some parts of code need to be updated. The changes impact pyth-evm-js example (therefore, only a patch version update) and pyth-evm-price-pusher logic (therefore, a major version update)

Also, there is one small refactor to crash on price pusher when the connection is suddenly closed. The reason is that the handling logic was not insufficient and crashing with restart is fine for the time being.