### PR TITLE
Bump common-js dependency versions + small refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ We require the [pre-commit hooks](https://pre-commit.com/) defined in [`.pre-com
 We use [Semantic Versioning](https://semver.org/) for our releases. In order to release a new version of any of the packages and publish it to npm, follow these steps:
 
 1. Run `npm version <new version number> --no-git-tag-version`. This command will update the version of the package. Then push your changes to github.
-2. Once your change is merged into `main`, create a release with tag `<package>:v<new version number>` like `pyth-evm-js:v1.5.2`, and a github action will automatically publish the new version of this package to npm.
+2. Once your change is merged into `main`, create a release with tag `<package>-v<new version number>` like `pyth-evm-js-v1.5.2`, and a github action will automatically publish the new version of this package to npm.

--- a/pyth-aptos-js/package-lock.json
+++ b/pyth-aptos-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@pythnetwork/pyth-common-js": "^1.0.0",
+        "@pythnetwork/pyth-common-js": "^1.2.0",
         "aptos": "^1.3.14",
         "buffer": "^6.0.3"
       },
@@ -1644,11 +1644,11 @@
       }
     },
     "node_modules/@pythnetwork/pyth-common-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-1.0.0.tgz",
-      "integrity": "sha512-I+Z3I00pT9SRGr9h/9uJ+BGcNXc3a2hxG/4WC3ZNm5xIVSYHtzl9qyJWLOajYXIfYR5w74dNMVe8e7a2/8W5Og==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-1.2.0.tgz",
+      "integrity": "sha512-GVBacwqMGcZC3H+Ol7DtK86HZlMvY3OujRnJs81WZGWEHWXJM5scot0ZGGqf7AC4U+LJbGLlN0uxR20Q/S7ixg==",
       "dependencies": {
-        "@pythnetwork/pyth-sdk-js": "^1.0.0",
+        "@pythnetwork/pyth-sdk-js": "^1.1.0",
         "@types/ws": "^8.5.3",
         "axios": "^0.26.1",
         "axios-retry": "^3.2.4",
@@ -1678,9 +1678,9 @@
       }
     },
     "node_modules/@pythnetwork/pyth-sdk-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.0.0.tgz",
-      "integrity": "sha512-nZ3tmn5EhR7Y6177cAE7p7iQJK40bipMUI4ZBwRhgTONOcg35jG0fsvlETZYgij0baQ1PMJQE6dIqZ50EMZpJw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.1.0.tgz",
+      "integrity": "sha512-IfZI/D+7HiA01TfzuA7Fh0SMhsE+hZWoI1pt48G+XMbNkXhiZG4lSQJRsnquSEY06YAFcAX2D66cFtV6BHy8IA=="
     },
     "node_modules/@scure/base": {
       "version": "1.0.0",
@@ -12561,11 +12561,11 @@
       }
     },
     "@pythnetwork/pyth-common-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-1.0.0.tgz",
-      "integrity": "sha512-I+Z3I00pT9SRGr9h/9uJ+BGcNXc3a2hxG/4WC3ZNm5xIVSYHtzl9qyJWLOajYXIfYR5w74dNMVe8e7a2/8W5Og==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-1.2.0.tgz",
+      "integrity": "sha512-GVBacwqMGcZC3H+Ol7DtK86HZlMvY3OujRnJs81WZGWEHWXJM5scot0ZGGqf7AC4U+LJbGLlN0uxR20Q/S7ixg==",
       "requires": {
-        "@pythnetwork/pyth-sdk-js": "^1.0.0",
+        "@pythnetwork/pyth-sdk-js": "^1.1.0",
         "@types/ws": "^8.5.3",
         "axios": "^0.26.1",
         "axios-retry": "^3.2.4",
@@ -12583,9 +12583,9 @@
       }
     },
     "@pythnetwork/pyth-sdk-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.0.0.tgz",
-      "integrity": "sha512-nZ3tmn5EhR7Y6177cAE7p7iQJK40bipMUI4ZBwRhgTONOcg35jG0fsvlETZYgij0baQ1PMJQE6dIqZ50EMZpJw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.1.0.tgz",
+      "integrity": "sha512-IfZI/D+7HiA01TfzuA7Fh0SMhsE+hZWoI1pt48G+XMbNkXhiZG4lSQJRsnquSEY06YAFcAX2D66cFtV6BHy8IA=="
     },
     "@scure/base": {
       "version": "1.0.0",

--- a/pyth-aptos-js/package-lock.json
+++ b/pyth-aptos-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-aptos-js",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-aptos-js",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/pyth-common-js": "^1.2.0",

--- a/pyth-aptos-js/package.json
+++ b/pyth-aptos-js/package.json
@@ -47,7 +47,7 @@
     "yargs": "^17.4.1"
   },
   "dependencies": {
-    "@pythnetwork/pyth-common-js": "^1.0.0",
+    "@pythnetwork/pyth-common-js": "^1.2.0",
     "aptos": "^1.3.14",
     "buffer": "^6.0.3"
   }

--- a/pyth-aptos-js/package.json
+++ b/pyth-aptos-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-aptos-js",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Pyth Network Aptos Utilities",
   "homepage": "https://pyth.network",
   "author": {

--- a/pyth-aptos-js/src/examples/AptosRelay.ts
+++ b/pyth-aptos-js/src/examples/AptosRelay.ts
@@ -4,8 +4,6 @@ import { hideBin } from "yargs/helpers";
 import { AptosPriceServiceConnection } from "../index";
 import { AptosAccount, AptosClient, TxnBuilderTypes } from "aptos";
 
-const APTOS_KEY = "APTOS_KEY";
-
 const argv = yargs(hideBin(process.argv))
   .option("price-ids", {
     description:
@@ -45,11 +43,11 @@ async function run() {
   );
 
   // Update the Pyth Contract using this update data
-  if (process.env[APTOS_KEY] === undefined) {
-    throw new Error(`${APTOS_KEY} environment variable should be set.`);
+  if (process.env.APTOS_KEY === undefined) {
+    throw new Error(`APTOS_KEY environment variable should be set.`);
   }
 
-  const sender = new AptosAccount(Buffer.from(process.env[APTOS_KEY], "hex"));
+  const sender = new AptosAccount(Buffer.from(process.env.APTOS_KEY, "hex"));
   const client = new AptosClient(argv.fullNode);
   const result = await client.generateSignSubmitWaitForTransaction(
     sender,

--- a/pyth-aptos-js/src/examples/AptosRelay.ts
+++ b/pyth-aptos-js/src/examples/AptosRelay.ts
@@ -45,7 +45,11 @@ async function run() {
   );
 
   // Update the Pyth Contract using this update data
-  const sender = new AptosAccount(Buffer.from(process.env[APTOS_KEY]!, "hex"));
+  if (process.env[APTOS_KEY] === undefined) {
+    throw new Error(`${APTOS_KEY} environment variable should be set.`);
+  }
+
+  const sender = new AptosAccount(Buffer.from(process.env[APTOS_KEY], "hex"));
   const client = new AptosClient(argv.fullNode);
   const result = await client.generateSignSubmitWaitForTransaction(
     sender,

--- a/pyth-evm-js/package-lock.json
+++ b/pyth-evm-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@pythnetwork/pyth-common-js": "^1.0.0",
+        "@pythnetwork/pyth-common-js": "^1.2.0",
         "buffer": "^6.0.3"
       },
       "devDependencies": {
@@ -1644,11 +1644,11 @@
       }
     },
     "node_modules/@pythnetwork/pyth-common-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-1.0.0.tgz",
-      "integrity": "sha512-I+Z3I00pT9SRGr9h/9uJ+BGcNXc3a2hxG/4WC3ZNm5xIVSYHtzl9qyJWLOajYXIfYR5w74dNMVe8e7a2/8W5Og==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-1.2.0.tgz",
+      "integrity": "sha512-GVBacwqMGcZC3H+Ol7DtK86HZlMvY3OujRnJs81WZGWEHWXJM5scot0ZGGqf7AC4U+LJbGLlN0uxR20Q/S7ixg==",
       "dependencies": {
-        "@pythnetwork/pyth-sdk-js": "^1.0.0",
+        "@pythnetwork/pyth-sdk-js": "^1.1.0",
         "@types/ws": "^8.5.3",
         "axios": "^0.26.1",
         "axios-retry": "^3.2.4",
@@ -1678,9 +1678,9 @@
       }
     },
     "node_modules/@pythnetwork/pyth-sdk-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.0.0.tgz",
-      "integrity": "sha512-nZ3tmn5EhR7Y6177cAE7p7iQJK40bipMUI4ZBwRhgTONOcg35jG0fsvlETZYgij0baQ1PMJQE6dIqZ50EMZpJw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.1.0.tgz",
+      "integrity": "sha512-IfZI/D+7HiA01TfzuA7Fh0SMhsE+hZWoI1pt48G+XMbNkXhiZG4lSQJRsnquSEY06YAFcAX2D66cFtV6BHy8IA=="
     },
     "node_modules/@pythnetwork/pyth-sdk-solidity": {
       "version": "2.2.0",
@@ -12499,11 +12499,11 @@
       }
     },
     "@pythnetwork/pyth-common-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-1.0.0.tgz",
-      "integrity": "sha512-I+Z3I00pT9SRGr9h/9uJ+BGcNXc3a2hxG/4WC3ZNm5xIVSYHtzl9qyJWLOajYXIfYR5w74dNMVe8e7a2/8W5Og==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-1.2.0.tgz",
+      "integrity": "sha512-GVBacwqMGcZC3H+Ol7DtK86HZlMvY3OujRnJs81WZGWEHWXJM5scot0ZGGqf7AC4U+LJbGLlN0uxR20Q/S7ixg==",
       "requires": {
-        "@pythnetwork/pyth-sdk-js": "^1.0.0",
+        "@pythnetwork/pyth-sdk-js": "^1.1.0",
         "@types/ws": "^8.5.3",
         "axios": "^0.26.1",
         "axios-retry": "^3.2.4",
@@ -12521,9 +12521,9 @@
       }
     },
     "@pythnetwork/pyth-sdk-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.0.0.tgz",
-      "integrity": "sha512-nZ3tmn5EhR7Y6177cAE7p7iQJK40bipMUI4ZBwRhgTONOcg35jG0fsvlETZYgij0baQ1PMJQE6dIqZ50EMZpJw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.1.0.tgz",
+      "integrity": "sha512-IfZI/D+7HiA01TfzuA7Fh0SMhsE+hZWoI1pt48G+XMbNkXhiZG4lSQJRsnquSEY06YAFcAX2D66cFtV6BHy8IA=="
     },
     "@pythnetwork/pyth-sdk-solidity": {
       "version": "2.2.0",

--- a/pyth-evm-js/package.json
+++ b/pyth-evm-js/package.json
@@ -49,7 +49,7 @@
     "yargs": "^17.4.1"
   },
   "dependencies": {
-    "@pythnetwork/pyth-common-js": "^1.0.0",
+    "@pythnetwork/pyth-common-js": "^1.2.0",
     "buffer": "^6.0.3"
   }
 }

--- a/pyth-terra-js/package-lock.json
+++ b/pyth-terra-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@pythnetwork/pyth-common-js": "^1.0.0",
+        "@pythnetwork/pyth-common-js": "^1.2.0",
         "@terra-money/terra.js": "^3.0.11",
         "axios": "^0.26.1"
       },
@@ -1089,11 +1089,11 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@pythnetwork/pyth-common-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-1.0.0.tgz",
-      "integrity": "sha512-I+Z3I00pT9SRGr9h/9uJ+BGcNXc3a2hxG/4WC3ZNm5xIVSYHtzl9qyJWLOajYXIfYR5w74dNMVe8e7a2/8W5Og==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-1.2.0.tgz",
+      "integrity": "sha512-GVBacwqMGcZC3H+Ol7DtK86HZlMvY3OujRnJs81WZGWEHWXJM5scot0ZGGqf7AC4U+LJbGLlN0uxR20Q/S7ixg==",
       "dependencies": {
-        "@pythnetwork/pyth-sdk-js": "^1.0.0",
+        "@pythnetwork/pyth-sdk-js": "^1.1.0",
         "@types/ws": "^8.5.3",
         "axios": "^0.26.1",
         "axios-retry": "^3.2.4",
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@pythnetwork/pyth-sdk-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.0.0.tgz",
-      "integrity": "sha512-nZ3tmn5EhR7Y6177cAE7p7iQJK40bipMUI4ZBwRhgTONOcg35jG0fsvlETZYgij0baQ1PMJQE6dIqZ50EMZpJw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.1.0.tgz",
+      "integrity": "sha512-IfZI/D+7HiA01TfzuA7Fh0SMhsE+hZWoI1pt48G+XMbNkXhiZG4lSQJRsnquSEY06YAFcAX2D66cFtV6BHy8IA=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -6594,11 +6594,11 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@pythnetwork/pyth-common-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-1.0.0.tgz",
-      "integrity": "sha512-I+Z3I00pT9SRGr9h/9uJ+BGcNXc3a2hxG/4WC3ZNm5xIVSYHtzl9qyJWLOajYXIfYR5w74dNMVe8e7a2/8W5Og==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-common-js/-/pyth-common-js-1.2.0.tgz",
+      "integrity": "sha512-GVBacwqMGcZC3H+Ol7DtK86HZlMvY3OujRnJs81WZGWEHWXJM5scot0ZGGqf7AC4U+LJbGLlN0uxR20Q/S7ixg==",
       "requires": {
-        "@pythnetwork/pyth-sdk-js": "^1.0.0",
+        "@pythnetwork/pyth-sdk-js": "^1.1.0",
         "@types/ws": "^8.5.3",
         "axios": "^0.26.1",
         "axios-retry": "^3.2.4",
@@ -6616,9 +6616,9 @@
       }
     },
     "@pythnetwork/pyth-sdk-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.0.0.tgz",
-      "integrity": "sha512-nZ3tmn5EhR7Y6177cAE7p7iQJK40bipMUI4ZBwRhgTONOcg35jG0fsvlETZYgij0baQ1PMJQE6dIqZ50EMZpJw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.1.0.tgz",
+      "integrity": "sha512-IfZI/D+7HiA01TfzuA7Fh0SMhsE+hZWoI1pt48G+XMbNkXhiZG4lSQJRsnquSEY06YAFcAX2D66cFtV6BHy8IA=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/pyth-terra-js/package-lock.json
+++ b/pyth-terra-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-terra-js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-terra-js",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/pyth-common-js": "^1.2.0",

--- a/pyth-terra-js/package.json
+++ b/pyth-terra-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-terra-js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Pyth Network Terra Utils in JS",
   "homepage": "https://pyth.network",
   "author": {

--- a/pyth-terra-js/package.json
+++ b/pyth-terra-js/package.json
@@ -43,7 +43,7 @@
     "yargs": "^17.4.1"
   },
   "dependencies": {
-    "@pythnetwork/pyth-common-js": "^1.0.0",
+    "@pythnetwork/pyth-common-js": "^1.2.0",
     "@terra-money/terra.js": "^3.0.11",
     "axios": "^0.26.1"
   }


### PR DESCRIPTION
The common-js dependency version was outdated on all other packages. This PR updates the version and bumps the upstream packages versions too:
- pyth-evm-js: It is not bumped as it is bumped in the previous PR.
- pyth-aptos-js: It is bumped to 1.0.0 as it is being used on mainnet.
- pyth-terra-js: A minor version bump as the pyth-common updates has no breaking change (added optional verbose option to price service connection)
