### PR TITLE
[evm] Bump a minor version

### DIFF
--- a/pyth-evm-js/package-lock.json
+++ b/pyth-evm-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-evm-js",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-evm-js",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@pythnetwork/pyth-common-js": "^1.2.0",

--- a/pyth-evm-js/package.json
+++ b/pyth-evm-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-evm-js",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Pyth Network EVM Utils in JS",
   "homepage": "https://pyth.network",
   "author": {


### PR DESCRIPTION
In the #73 I updated the packages dependencies to pyth-common-js but did not bump pyth-evm-js as I thought it is bumped before. But then I realized that the version bump was a patch and it's not enough for the changeset. This PR makes a minor version bump.