### PR TITLE
Fix wrong method name in README example

### DIFF
--- a/pyth-evm-js/README.md
+++ b/pyth-evm-js/README.md
@@ -38,7 +38,7 @@ const priceIds = [
 // In order to use Pyth prices in your protocol you need to submit the price update data to Pyth contract in your target
 // chain. `getPriceUpdateData` creates the update data which can be submitted to your contract. Then your contract should
 // call the Pyth Contract with this data.
-const priceUpdateData = await connection.getPriceUpdateData(priceIds);
+const priceUpdateData = await connection.getPriceFeedsUpdateData(priceIds);
 
 // If the user is paying the price update fee, you need to fetch it from the Pyth contract.
 // Please refer to https://docs.pyth.network/consume-data/on-demand#fees for more information.

--- a/pyth-evm-js/README.md
+++ b/pyth-evm-js/README.md
@@ -36,7 +36,7 @@ const priceIds = [
 ];
 
 // In order to use Pyth prices in your protocol you need to submit the price update data to Pyth contract in your target
-// chain. `getPriceUpdateData` creates the update data which can be submitted to your contract. Then your contract should
+// chain. `getPriceFeedsUpdateData` creates the update data which can be submitted to your contract. Then your contract should
 // call the Pyth Contract with this data.
 const priceUpdateData = await connection.getPriceFeedsUpdateData(priceIds);
 

--- a/pyth-evm-js/README.md
+++ b/pyth-evm-js/README.md
@@ -46,7 +46,7 @@ const priceUpdateData = await connection.getPriceFeedsUpdateData(priceIds);
 // `pythContract` below is a web3.js contract; if you wish to use ethers, you need to change it accordingly.
 // You can find the Pyth interface ABI in @pythnetwork/pyth-sdk-solidity npm package.
 const updateFee = await pythContract.methods
-  .getUpdateFee(priceFeedUpdateData)
+  .getUpdateFee(priceUpdateData)
   .call();
 // Calling someContract method
 // `someContract` below is a web3.js contract; if you wish to use ethers, you need to change it accordingly.


### PR DESCRIPTION
The method `getPriceData` called in the README example, does not exist on `EvmPriceServiceConnection`, I assume the example should use the method `getPriceFeedsData` instead: https://github.com/pyth-network/pyth-js/blob/eadb2c5386ada06eb99b5b56cd7805d7fed713d9/pyth-evm-js/src/EvmPriceServiceConnection.ts#L12