### PR TITLE
Improve repo and pyth-evm-js docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 .dccache
+*mnemonic*

--- a/pyth-evm-js/README.md
+++ b/pyth-evm-js/README.md
@@ -142,7 +142,14 @@ npm run example-client -- --endpoint https://xc-testnet.pyth.network --price-ids
 You can run this example with `npm run example-relay`. A full command that updates BTC and ETH prices on the BNB Chain testnet network looks like so:
 
 ```bash
-npm run example-relay -- --network bnb_testnet --mnemonic "my good mnemonic" --endpoint https://xc-testnet.pyth.network --price-ids 0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b 0xca80ba6dc32e08d06f1aa886011eed1d77c77be9eb761cc10d72b7d0a2fd57a6
+npm run example-relay -- \
+  --network "https://data-seed-prebsc-1-s1.binance.org:8545" \
+  --pyth-contract "0xd7308b14BF4008e7C7196eC35610B1427C5702EA"\
+  --mnemonic "my good mnemonic" \
+  --endpoint https://xc-testnet.pyth.network \
+  --price-ids \
+    "0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b" \
+    "0xca80ba6dc32e08d06f1aa886011eed1d77c77be9eb761cc10d72b7d0a2fd57a6"
 ```
 
 ## Price Service endpoints


### PR DESCRIPTION
This PR is to address the feedbacks on the deployment process:
- Adds `*mnemonic*` to git ignore to avoid adding them to git.
- Simplifies the `EvmRelay.ts` example. It had some RPC endpoints for some networks inside which
  makes it hard to maintain. Removed them entirely and updated the Readme so people don't get confused.