### PR TITLE
[common] Add binary request config + bump v

### DIFF
--- a/pyth-common-js/package-lock.json
+++ b/pyth-common-js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@pythnetwork/pyth-common-js",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-common-js",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@pythnetwork/pyth-sdk-js": "^1.1.0",
+        "@pythnetwork/pyth-sdk-js": "^1.2.0",
         "@types/ws": "^8.5.3",
         "axios": "^0.26.1",
         "axios-retry": "^3.2.4",
@@ -1011,9 +1011,9 @@
       }
     },
     "node_modules/@pythnetwork/pyth-sdk-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.1.0.tgz",
-      "integrity": "sha512-IfZI/D+7HiA01TfzuA7Fh0SMhsE+hZWoI1pt48G+XMbNkXhiZG4lSQJRsnquSEY06YAFcAX2D66cFtV6BHy8IA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.2.0.tgz",
+      "integrity": "sha512-grh6YCkp/nH73ACNu+Mew64lLVgz6egVBJm8JvdNkRggWkUn1PE4ZvV/6ceTIui5OhI369qzMCkldiAlIMBjnQ=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -6014,9 +6014,9 @@
       }
     },
     "@pythnetwork/pyth-sdk-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.1.0.tgz",
-      "integrity": "sha512-IfZI/D+7HiA01TfzuA7Fh0SMhsE+hZWoI1pt48G+XMbNkXhiZG4lSQJRsnquSEY06YAFcAX2D66cFtV6BHy8IA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@pythnetwork/pyth-sdk-js/-/pyth-sdk-js-1.2.0.tgz",
+      "integrity": "sha512-grh6YCkp/nH73ACNu+Mew64lLVgz6egVBJm8JvdNkRggWkUn1PE4ZvV/6ceTIui5OhI369qzMCkldiAlIMBjnQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/pyth-common-js/package.json
+++ b/pyth-common-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-common-js",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Pyth Network Common Utils in JS",
   "author": {
     "name": "Pyth Data Association"
@@ -41,7 +41,7 @@
     "yargs": "^17.4.1"
   },
   "dependencies": {
-    "@pythnetwork/pyth-sdk-js": "^1.1.0",
+    "@pythnetwork/pyth-sdk-js": "^1.2.0",
     "@types/ws": "^8.5.3",
     "axios": "^0.26.1",
     "axios-retry": "^3.2.4",

--- a/pyth-common-js/src/examples/PriceServiceClient.ts
+++ b/pyth-common-js/src/examples/PriceServiceClient.ts
@@ -31,6 +31,9 @@ const argv = yargs(hideBin(process.argv))
 async function run() {
   const connection = new PriceServiceConnection(argv.endpoint, {
     logger: console, // Providing logger will allow the connection to log it's events.
+    priceFeedRequestConfig: {
+      binary: true,
+    },
   });
 
   const priceIds = argv.priceIds as string[];
@@ -46,6 +49,7 @@ async function run() {
         priceFeed.getPriceNoOlderThan(60)
       )}.`
     );
+    console.log(priceFeed.getVAA());
   });
 
   await sleep(600000);


### PR DESCRIPTION
This PR adds binary request config to the PriceServiceConnection and releases a new minor version. A few notes:
- I moved `verbose` and `binary` to a separate struct as they are more a configuration for some specific types of requests. To keep backward compatibility I kept `verbose` option on constructor too.
- I added this `binary` option to the example as it is useful for people.