### PR TITLE
Deprecate the pyth-js repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pyth JS
 
-:warning: **Warning** The content of this repository is being moved into [pyth-crosschain](https://github.com/pyth-network/pyth-crosschain).
+:warning: **Warning** This repository is **deprecated**. The code that used to live here has moved into [pyth-crosschain](https://github.com/pyth-network/pyth-crosschain).
 Please see `target_chains/<chain_name>/sdk/js` for the relevant chain-specific JS SDK, and `price_pusher` for the price pusher.
 
 The Pyth JS repo provides utilities for consuming price feeds from the [pyth.network](https://pyth.network/) oracle in JavaScript.


### PR DESCRIPTION
Everything that used to be in here now lives in pyth-crosschain. I'll archive the repo as well.